### PR TITLE
Chore: iOS TestFlight 배포 설정

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,11 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.eum-mobile"
+      "bundleIdentifier": "com.eum-dating.app",
+      "buildNumber": "2",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/eas.json
+++ b/eas.json
@@ -8,6 +8,19 @@
       "ios": {
         "simulator": false
       }
+    },
+    "production": {
+      "distribution": "store",
+      "ios": {
+        "simulator": false
+      }
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "ascAppId": "6785847778"
+      }
     }
   }
 }

--- a/ios/eummobile.xcodeproj/project.pbxproj
+++ b/ios/eummobile.xcodeproj/project.pbxproj
@@ -241,7 +241,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -259,7 +259,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.anonymous.eum-mobile";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.eum-dating.app";
 				PRODUCT_NAME = "eummobile";
 				SWIFT_OBJC_BRIDGING_HEADER = "eummobile/eummobile-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -275,7 +275,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				INFOPLIST_FILE = eummobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -288,7 +288,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.anonymous.eum-mobile";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.eum-dating.app";
 				PRODUCT_NAME = "eummobile";
 				SWIFT_OBJC_BRIDGING_HEADER = "eummobile/eummobile-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/eummobile/Info.plist
+++ b/ios/eummobile/Info.plist
@@ -28,12 +28,14 @@
         <key>CFBundleURLSchemes</key>
         <array>
           <string>eummobile</string>
-          <string>com.anonymous.eum-mobile</string>
+          <string>com.eum-dating.app</string>
         </array>
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>LSMinimumSystemVersion</key>
     <string>12.0</string>
     <key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## 작업 내용
- iOS 번들 ID를 App Store Connect 등록값으로 변경
- TestFlight용 EAS production build/submit 설정 추가
- iOS build number를 2로 증가
- 수출 규정 암호화 플래그 설정

## 검증
- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * iOS 앱의 식별 정보와 버전이 업데이트되어 최신 배포 기준에 맞게 정리되었습니다.
  * 앱의 외부 식별자가 새 이름으로 변경되었습니다.

* **변경 사항**
  * iOS 배포 설정이 갱신되어 스토어 제출 및 빌드 정보가 최신 상태로 반영되었습니다.
  * 암호화 관련 안내 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->