### PR TITLE
fix: 사진 접근 권한 거부 상태 처리

### DIFF
--- a/app/profile/photo.tsx
+++ b/app/profile/photo.tsx
@@ -9,6 +9,7 @@ import {
   Animated,
   Dimensions,
   Image as RNImage,
+  Linking,
   Modal,
   PanResponder,
   Platform,
@@ -124,10 +125,26 @@ export default function PhotoScreen() {
   };
 
   const pickImageFromGallery = async () => {
-    const permissionResult =
-      await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (permissionResult.status !== "granted") {
-      alert("갤러리 접근 권한이 필요합니다.");
+    let permissionResult = await ImagePicker.getMediaLibraryPermissionsAsync();
+
+    if (!permissionResult.granted && permissionResult.canAskAgain) {
+      permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    }
+
+    if (!permissionResult.granted) {
+      Alert.alert(
+        "갤러리 접근 권한 필요",
+        "설정에서 사진 접근 권한을 허용해주세요.",
+        [
+          { text: "취소", style: "cancel" },
+          {
+            text: "설정 열기",
+            onPress: () => {
+              void Linking.openSettings();
+            },
+          },
+        ],
+      );
       throw new Error("Media library permission denied.");
     }
 

--- a/eas.json
+++ b/eas.json
@@ -4,12 +4,14 @@
   },
   "build": {
     "preview": {
+      "environment": "preview",
       "distribution": "internal",
       "ios": {
         "simulator": false
       }
     },
     "production": {
+      "environment": "production",
       "distribution": "store",
       "ios": {
         "simulator": false


### PR DESCRIPTION
## 변경 사항
- EAS 빌드 profile별 environment를 명시했습니다.
- 프로필 사진 선택 시 사진 접근 권한이 이미 거부된 경우 설정 앱으로 이동할 수 있게 했습니다.

## 검증
- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 갤러리에서 사진을 고를 때 미디어 접근 권한 확인 방식이 개선되었습니다.
  * 권한이 없을 경우 안내 메시지가 더 명확해졌고, 설정 화면으로 바로 이동할 수 있습니다.
* **Chores**
  * 미리보기와 프로덕션 빌드 환경이 각각 명시적으로 구분되도록 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->