### PR TITLE
fix: 동호회 생성/탈퇴 플로우 보완

### DIFF
--- a/app/club/create.tsx
+++ b/app/club/create.tsx
@@ -18,12 +18,17 @@ import Cta from "@/components/Cta";
 import { Chip } from "@/components/Chip";
 import TextBox from "@/components/TextBox";
 import { CLUB_CREATE_CATEGORIES } from "@/constants/club";
+import { postPresign, uploadFileToS3 } from "@/api/onboarding/onboardingApi";
 import { useCreateClubMutation } from "@/hooks/api/useClub";
 
 const categories = CLUB_CREATE_CATEGORIES.map((item) => item.label);
 
 type JoinType = "free" | "approval";
 type BoardScope = "all" | "member";
+type CoverImage = {
+  uri: string;
+  contentType: string;
+};
 
 export default function ClubCreateScreen() {
   const router = useRouter();
@@ -34,7 +39,8 @@ export default function ClubCreateScreen() {
   const [maxMembers, setMaxMembers] = useState(15);
   const [joinType, setJoinType] = useState<JoinType>("free");
   const [boardScope, setBoardScope] = useState<BoardScope>("member");
-  const [coverImageUris, setCoverImageUris] = useState<string[]>([]);
+  const [coverImages, setCoverImages] = useState<CoverImage[]>([]);
+  const [isUploadingCover, setUploadingCover] = useState(false);
 
   const canSubmit = useMemo(
     () => name.trim().length > 0 && intro.trim().length > 0 && !!category && !!region,
@@ -59,7 +65,12 @@ export default function ClubCreateScreen() {
       });
 
       if (!result.canceled) {
-        setCoverImageUris(result.assets.slice(0, 5).map((asset) => asset.uri));
+        setCoverImages(
+          result.assets.slice(0, 5).map((asset) => ({
+            uri: asset.uri,
+            contentType: asset.mimeType ?? resolveImageContentType(asset.uri),
+          })),
+        );
       }
     } catch (error) {
       console.error("Cover Image Picker Error:", error);
@@ -69,40 +80,40 @@ export default function ClubCreateScreen() {
 
   const createClubMutation = useCreateClubMutation();
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const categoryValue =
       CLUB_CREATE_CATEGORIES.find((item) => item.label === category)?.value ??
       "OTHERS";
 
-    createClubMutation.mutate(
-      {
+    try {
+      setUploadingCover(true);
+      const thumbnailUrl = coverImages[0]
+        ? await uploadClubCoverImage(coverImages[0])
+        : null;
+      const club = await createClubMutation.mutateAsync({
         name: name.trim(),
         category: categoryValue,
         introText: intro.trim(),
-        // ponytail: 음성/키워드 UI 없음 — 서버 필수값이라 빈 값 전송, 거부 시 백엔드 협의
-        introVoice: "",
+        thumbnailUrl,
         capacity: maxMembers,
-        keywordIds: [],
-      },
-      {
-        onSuccess: (club) => {
-          router.push({
-            pathname: "/club/create-complete",
-            params: {
-              clubId: String(club.clubId),
-              name: club.name,
-              intro: intro.trim(),
-              location: region,
-              host: club.host?.nickname ?? "",
-              image: coverImageUris[0] ?? "",
-            },
-          } as never);
+      });
+
+      router.push({
+        pathname: "/club/create-complete",
+        params: {
+          clubId: String(club.clubId),
+          name: club.name,
+          intro: intro.trim(),
+          location: region,
+          host: club.host?.nickname ?? "",
+          image: thumbnailUrl ?? coverImages[0]?.uri ?? "",
         },
-        onError: () => {
-          Alert.alert("동호회 생성 실패", "잠시 후 다시 시도해주세요.");
-        },
-      },
-    );
+      } as never);
+    } catch {
+      Alert.alert("동호회 생성 실패", "잠시 후 다시 시도해주세요.");
+    } finally {
+      setUploadingCover(false);
+    }
   };
 
   return (
@@ -130,10 +141,10 @@ export default function ClubCreateScreen() {
           style={styles.coverBox}
           onPress={handlePickCoverImages}
         >
-          {coverImageUris[0] ? (
+          {coverImages[0] ? (
             <>
               <Image
-                source={{ uri: coverImageUris[0] }}
+                source={{ uri: coverImages[0].uri }}
                 style={styles.coverImage}
                 contentFit="cover"
               />
@@ -141,7 +152,7 @@ export default function ClubCreateScreen() {
               <View style={styles.coverEditBadge}>
                 <Ionicons name="camera" size={17} color="#FFFFFF" />
                 <Text style={styles.coverEditText}>
-                  {coverImageUris.length}/5
+                  {coverImages.length}/5
                 </Text>
               </View>
             </>
@@ -279,13 +290,52 @@ export default function ClubCreateScreen() {
 
       <Cta
         label={canSubmit ? "동호회 만들기" : "다음"}
-        disabled={!canSubmit || createClubMutation.isPending}
+        disabled={!canSubmit || createClubMutation.isPending || isUploadingCover}
         onPress={handleSubmit}
         buttonStyle={styles.ctaButton}
         labelStyle={styles.ctaLabel}
       />
     </SafeAreaView>
   );
+}
+
+async function uploadClubCoverImage(image: CoverImage) {
+  const extension = contentTypeToImageExtension(image.contentType);
+  const { uploadUrl, fileUrl } = await postPresign({
+    fileName: `club-cover-${Date.now()}.${extension}`,
+    contentType: image.contentType,
+    purpose: "PROFILE_IMAGE",
+  });
+  const fileResponse = await fetch(image.uri);
+  const blob = await fileResponse.blob();
+  const uploadBlob = blob.type
+    ? blob
+    : new Blob([blob], { type: image.contentType });
+
+  await uploadFileToS3(uploadUrl, uploadBlob, image.contentType);
+
+  return fileUrl;
+}
+
+function resolveImageContentType(uri: string) {
+  const lowerUri = uri.toLowerCase();
+
+  if (lowerUri.startsWith("data:image/png") || lowerUri.endsWith(".png")) {
+    return "image/png";
+  }
+
+  if (lowerUri.startsWith("data:image/webp") || lowerUri.endsWith(".webp")) {
+    return "image/webp";
+  }
+
+  return "image/jpeg";
+}
+
+function contentTypeToImageExtension(contentType: string) {
+  if (contentType === "image/png") return "png";
+  if (contentType === "image/webp") return "webp";
+
+  return "jpg";
 }
 
 function FormSection({ children }: { children: React.ReactNode }) {

--- a/app/club/detail.tsx
+++ b/app/club/detail.tsx
@@ -20,7 +20,11 @@ import {
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { CLUB_CATEGORY_LABELS } from "@/constants/club";
-import { useClubDetailQuery, useJoinClubMutation } from "@/hooks/api/useClub";
+import {
+  useClubDetailQuery,
+  useJoinClubMutation,
+  useLeaveClubMutation,
+} from "@/hooks/api/useClub";
 import { ClubMemberStatus } from "@/types/api/club/clubDTO";
 import { ClubPostCategory } from "@/types/api/clubs/clubPostsDTO";
 import { IMeetingListItem } from "@/types/api/meetings/meetingsDTO";
@@ -181,9 +185,10 @@ export default function ClubDetailScreen() {
 
   const detailQuery = useClubDetailQuery(clubId);
   const joinMutation = useJoinClubMutation(clubId);
+  const leaveMutation = useLeaveClubMutation();
   const detail = detailQuery.data;
 
-  const isJoined = detail?.isJoined || joinStatus === "ACTIVE";
+  const isJoined = joinStatus === "ACTIVE" || (detail?.isJoined && joinStatus !== "LEFT");
   const isJoinPending = joinStatus === "PENDING";
   const bottomBarHeight = isJoined
     ? insets.bottom + (activeTab === "board" ? 110 : 24)
@@ -233,11 +238,17 @@ export default function ClubDetailScreen() {
     );
   };
 
-  // ponytail: 탈퇴 API 연동은 이번 범위 밖 — 로컬 상태만 초기화
   const handleLeaveConfirm = () => {
-    setLeaveConfirmVisible(false);
-    setJoinStatus(null);
-    setActiveTab("home");
+    leaveMutation.mutate(clubId, {
+      onSuccess: () => {
+        setLeaveConfirmVisible(false);
+        setJoinStatus("LEFT");
+        setActiveTab("home");
+      },
+      onError: () => {
+        Alert.alert("탈퇴 실패", "잠시 후 다시 시도해주세요.");
+      },
+    });
   };
 
   return (
@@ -425,6 +436,7 @@ export default function ClubDetailScreen() {
 
       <LeaveConfirmModal
         visible={isLeaveConfirmVisible}
+        isSubmitting={leaveMutation.isPending}
         onCancel={() => setLeaveConfirmVisible(false)}
         onConfirm={handleLeaveConfirm}
       />
@@ -1105,10 +1117,12 @@ function LeaveActionSheet({
 
 function LeaveConfirmModal({
   visible,
+  isSubmitting,
   onCancel,
   onConfirm,
 }: {
   visible: boolean;
+  isSubmitting: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 }) {
@@ -1127,10 +1141,18 @@ function LeaveConfirmModal({
             정말 탈퇴하시나요.{"\n"}한번 동호회를 탈퇴하면 재가입이 어려워요.
           </Text>
           <View style={styles.confirmButtonRow}>
-            <Pressable style={styles.cancelButton} onPress={onCancel}>
+            <Pressable
+              style={styles.cancelButton}
+              onPress={onCancel}
+              disabled={isSubmitting}
+            >
               <Text style={styles.cancelButtonText}>취소</Text>
             </Pressable>
-            <Pressable style={styles.leaveConfirmButton} onPress={onConfirm}>
+            <Pressable
+              style={styles.leaveConfirmButton}
+              onPress={onConfirm}
+              disabled={isSubmitting}
+            >
               <Text style={styles.leaveConfirmButtonText}>탈퇴</Text>
             </Pressable>
           </View>

--- a/components/club/ClubJoinRequestSheet.tsx
+++ b/components/club/ClubJoinRequestSheet.tsx
@@ -1,13 +1,14 @@
 import { Image } from "expo-image";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
-  KeyboardAvoidingView,
+  Keyboard,
   Modal,
   Platform,
   Pressable,
   StyleSheet,
   Text,
   TextInput,
+  useWindowDimensions,
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -44,7 +45,38 @@ export default function ClubJoinRequestSheet({
   isApprovalRequired = false,
 }: Props) {
   const insets = useSafeAreaInsets();
+  const { height: windowHeight } = useWindowDimensions();
   const canSubmit = message.trim().length > 0;
+  const [sheetLift, setSheetLift] = useState(0);
+
+  useEffect(() => {
+    const showEvent =
+      Platform.OS === "ios" ? "keyboardWillChangeFrame" : "keyboardDidShow";
+    const hideEvent =
+      Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+    const showSubscription = Keyboard.addListener(showEvent, (event) => {
+      const keyboardHeight =
+        Platform.OS === "ios"
+          ? Math.max(0, windowHeight - event.endCoordinates.screenY)
+          : event.endCoordinates.height;
+
+      setSheetLift(Math.max(0, keyboardHeight - insets.bottom));
+    });
+    const hideSubscription = Keyboard.addListener(hideEvent, () => {
+      setSheetLift(0);
+    });
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, [insets.bottom, windowHeight]);
+
+  useEffect(() => {
+    if (!visible) {
+      setSheetLift(0);
+    }
+  }, [visible]);
 
   return (
     <Modal
@@ -53,13 +85,18 @@ export default function ClubJoinRequestSheet({
       animationType="slide"
       onRequestClose={onClose}
     >
-      <KeyboardAvoidingView
-        style={styles.overlay}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-      >
+      <View style={styles.overlay}>
         <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
 
-        <View style={[styles.sheet, { paddingBottom: insets.bottom + 24 }]}>
+        <View
+          style={[
+            styles.sheet,
+            {
+              paddingBottom: insets.bottom + 24,
+              transform: [{ translateY: -sheetLift }],
+            },
+          ]}
+        >
           <View style={styles.handleArea}>
             <View style={styles.handle} />
           </View>
@@ -136,7 +173,7 @@ export default function ClubJoinRequestSheet({
             />
           </View>
         </View>
-      </KeyboardAvoidingView>
+      </View>
     </Modal>
   );
 }

--- a/types/api/club/clubDTO.ts
+++ b/types/api/club/clubDTO.ts
@@ -62,9 +62,8 @@ export interface IClubCreateRequest {
   name: string;
   category: ClubCategory;
   introText: string;
-  introVoice?: string | null;
+  thumbnailUrl?: string | null;
   capacity: number;
-  keywordIds: number[];
 }
 
 export interface IClubCreateResponse {


### PR DESCRIPTION
## 변경 사항

### 동호회 생성 커버 이미지 업로드
- 동호회 생성 시 선택한 커버 이미지의 첫 번째 이미지를 업로드하도록 연결했습니다.
- 이미지 선택 결과에서 로컬 uri와 contentType을 함께 보관합니다.
- 생성 버튼 클릭 시 다음 순서로 처리합니다.
  1. /v1/files/presign 호출
  2. 로컬 이미지 uri를 blob으로 변환
  3. presigned uploadUrl로 S3 PUT 업로드
  4. 반환받은 fileUrl을 thumbnailUrl로 /v1/clubs 생성 요청에 첨부
- 생성 완료 화면에서도 업로드된 thumbnailUrl을 우선 표시하도록 수정했습니다.
- 업로드/생성 중에는 생성 버튼이 중복 클릭되지 않게 막았습니다.

### 동호회 생성 요청 스키마 정리
- 백엔드 스펙 변경에 맞춰 생성 body에서 introVoice, keywordIds를 제거했습니다.
- IClubCreateRequest 타입에 thumbnailUrl을 추가했습니다.

### 동호회 탈퇴 API 연결
- 기존에 로컬 상태만 바꾸던 탈퇴 확인 액션을 실제 leaveClub API로 연결했습니다.
- 탈퇴 성공 시 상세 화면의 로컬 가입 상태를 LEFT로 변경해 가입 CTA 상태로 돌아오게 했습니다.
- 탈퇴 실패 시 alert를 표시합니다.
- 탈퇴 요청 중 확인 모달의 취소/탈퇴 버튼 중복 클릭을 막았습니다.

### 가입 신청 모달 키보드 대응
- 가입 메시지 입력 시 키보드가 바텀시트를 덮는 문제를 완화했습니다.
- KeyboardAvoidingView 대신 키보드 frame 이벤트를 사용해 실제 키보드 높이를 계산하고, 시트를 translateY로 올리도록 수정했습니다.

## 검증
- pnpm lint 통과

## 남은 이슈 / 후속 작업
- 커버 이미지는 현재 첫 번째 이미지만 thumbnailUrl로 업로드합니다. 여러 장 저장이 필요하면 백엔드의 이미지 배열 필드가 확정된 뒤 확장해야 합니다.
- presign purpose는 클럽 전용 값이 아직 없어 기존 PROFILE_IMAGE를 재사용했습니다. 백엔드에서 클럽 전용 purpose를 제공하면 해당 값으로 교체해야 합니다.
- 가입 신청 모달 키보드 대응은 코드상 보완했지만, 기기/키보드 종류에 따라 추가 조정이 필요할 수 있습니다.

## PR 전 처리
- 최신 origin/dev 기준 새 브랜치에서 작업했습니다.
- .claude/ 로컬 파일은 커밋하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 동호회 생성 시 커버 이미지를 여러 장 선택하고 미리볼 수 있게 개선했습니다.
  * 생성 완료 후 대표 이미지가 함께 반영되도록 변경했습니다.

* **Bug Fixes**
  * 커버 이미지 업로드 중에는 생성 버튼이 비활성화되도록 수정했습니다.
  * 동호회 탈퇴가 실제 처리되도록 개선하고, 진행 중 중복 실행을 막았습니다.
  * 가입 요청 시 키보드 동작에 맞춰 입력 화면이 더 자연스럽게 올라가도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->