### PR TITLE
fix: 마음함 나이/거주지 표시 + 프로필 상세 스키마 정합 (누락분 재반영)

### DIFF
--- a/api/axiosInstance.ts
+++ b/api/axiosInstance.ts
@@ -23,6 +23,25 @@ const normalizedBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL?.replace(
 );
 const REFRESH_TOKEN_PATH = "/v1/auth/token/refresh";
 
+const getJwtDebugInfo = (token: string | null) => {
+  if (!token) return null;
+
+  try {
+    const payload = JSON.parse(
+      atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")),
+    ) as { exp?: number; sub?: string; userId?: number | string };
+
+    return {
+      exp: payload.exp,
+      expired: payload.exp ? payload.exp * 1000 <= Date.now() : undefined,
+      sub: payload.sub,
+      userId: payload.userId,
+    };
+  } catch {
+    return { parseFailed: true };
+  }
+};
+
 const api = axios.create({
   baseURL: normalizedBaseUrl,
   headers: { "Content-Type": "application/json" },
@@ -59,7 +78,11 @@ api.interceptors.request.use((config) => {
   }
   if (__DEV__) {
     const method = config.method?.toUpperCase() ?? "GET";
-    console.log(`[API Request] ${method} ${config.baseURL}${config.url}`);
+    console.log(`[API Request] ${method} ${config.baseURL}${config.url}`, {
+      hasAuthorizationHeader: Boolean(config.headers.Authorization),
+      hasToken: Boolean(token),
+      token: getJwtDebugInfo(token),
+    });
   }
   return config;
 });

--- a/api/users/usersApi.ts
+++ b/api/users/usersApi.ts
@@ -1,7 +1,7 @@
 import api from "../axiosInstance";
 import { ApiSuccessResponse } from "../../types/api/api";
 
-import { IUserProfile } from "../../types/user";
+import { IUserProfile, IUserPublicProfile } from "../../types/user";
 import {
   IKeywordsRequest,
   ILikedClubsParams,
@@ -20,10 +20,10 @@ export const getMyProfile = async () => {
   return data.success.data;
 };
 
-//v1/users/{userId}
+//v1/users/{userId}/profile
 export const getUserProfile = async (userId: number) => {
-  const { data } = await api.get<ApiSuccessResponse<IUserProfile>>(
-    `/v1/users/${userId}`,
+  const { data } = await api.get<ApiSuccessResponse<IUserPublicProfile>>(
+    `/v1/users/${userId}/profile`,
   );
 
   return data.success.data;

--- a/app/(tabs)/heart.tsx
+++ b/app/(tabs)/heart.tsx
@@ -22,6 +22,7 @@ import {
   useSentHeartsInfiniteQuery,
 } from "@/hooks/api/useSocials";
 import { TAB_SCREEN_BOTTOM_PADDING } from "@/constants/layout";
+import { getAgeFromBirthdate } from "@/utils/age";
 import type {
   IHeartreceivedResponse,
   IHeartsentResponse,
@@ -42,7 +43,7 @@ type HeartProfile = {
   id: string;
   targetUserId: number;
   name: string;
-  age: number;
+  age: number | null;
   location: string;
   image: string;
   isLiked: boolean;
@@ -356,7 +357,7 @@ function mapReceivedHeartProfiles(
           likedHeartId,
           targetUserId: item.fromUserId,
           name: item.fromUser.nickname,
-          age: item.fromUser.age,
+          age: getAgeFromBirthdate(item.fromUser.birthdate),
           location: getProfileLocation(item.fromUser),
           image: item.fromUser.profileImageUrl || FALLBACK_PROFILE_IMAGE,
           isLiked: likedHeartId != null,
@@ -376,7 +377,7 @@ function mapSentHeartProfiles(
         likedHeartId: item.heartId,
         targetUserId: item.targetUserId,
         name: item.targetUser.nickname,
-        age: item.targetUser.age,
+        age: getAgeFromBirthdate(item.targetUser.birthdate),
         location: getProfileLocation(item.targetUser),
         image: item.targetUser.profileImageUrl || FALLBACK_PROFILE_IMAGE,
         isLiked: true,
@@ -385,20 +386,23 @@ function mapSentHeartProfiles(
   );
 }
 
-// 마음 응답의 상대 정보엔 지역이 없을 수 있음 — 서버가 주면 표시, 없으면 빈 값
+// 마음 응답의 지역은 address.fullName로 내려옴 — 없으면 빈 값
 function getProfileLocation(profile: IProfileSummary) {
-  return profile.areaName?.trim() || profile.area?.name?.trim() || "";
+  return profile.address?.fullName?.trim() || "";
 }
 
 function buildProfileDetailParams(profile: ScreenHeartProfile) {
   const params: Record<string, string> = {
     userId: String(profile.targetUserId),
     name: profile.name,
-    age: String(profile.age),
     image: profile.image,
     location: profile.location,
     isLiked: String(profile.isLiked),
   };
+
+  if (profile.age != null) {
+    params.age = String(profile.age);
+  }
 
   if (profile.likedHeartId) {
     params.heartId = String(profile.likedHeartId);
@@ -466,8 +470,12 @@ function HeartProfileCard({
             <Text style={styles.cardName} numberOfLines={1}>
               {profile.name}
             </Text>
-            <View style={styles.nameDot} />
-            <Text style={styles.cardName}>{profile.age}세</Text>
+            {profile.age != null ? (
+              <>
+                <View style={styles.nameDot} />
+                <Text style={styles.cardName}>{profile.age}세</Text>
+              </>
+            ) : null}
           </View>
           {profile.location ? (
             <Text style={styles.cardLocation} numberOfLines={1}>

--- a/app/(tabs)/heart.tsx
+++ b/app/(tabs)/heart.tsx
@@ -22,12 +22,19 @@ import {
   useSentHeartsInfiniteQuery,
 } from "@/hooks/api/useSocials";
 import { TAB_SCREEN_BOTTOM_PADDING } from "@/constants/layout";
+import type {
+  IHeartreceivedResponse,
+  IHeartsentResponse,
+  IProfileSummary,
+} from "@/types/api/socials/socialsDTO";
 
 const PINK = "#FF3E70";
 const BLACK = "#202020";
 const GRAY_100 = "#F8FAFB";
 const GRAY_150 = "#E9ECED";
 const GRAY_700 = "#636970";
+const FALLBACK_PROFILE_IMAGE =
+  "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?q=85&w=1200&auto=format&fit=crop";
 
 type HeartTab = "received" | "sent";
 
@@ -333,33 +340,15 @@ function applyOptimisticHeartState<T extends ScreenHeartProfile>(
   });
 }
 
+// 받은 마음 응답엔 좋아요 여부가 없어, 보낸 마음 목록과 대조해 맞하트를 판단
 function mapReceivedHeartProfiles(
-  data:
-    | {
-        pages: {
-          items: {
-            heartId: number;
-            fromUserId: number;
-            isLiked?: boolean;
-            likedHeartId?: number | null;
-            fromUser: {
-              nickname: string;
-              age: number;
-              areaName?: string | null;
-              area?: { name?: string | null } | null;
-              profileImageUrl: string;
-            };
-          }[];
-        }[];
-      }
-    | undefined,
+  data: { pages: IHeartreceivedResponse[] } | undefined,
   sentHeartIdsByTargetUserId: Map<number, number>,
 ): ScreenHeartProfile[] {
   return (
     data?.pages.flatMap((page) =>
       page.items.map((item) => {
-        const likedHeartId =
-          item.likedHeartId ?? sentHeartIdsByTargetUserId.get(item.fromUserId);
+        const likedHeartId = sentHeartIdsByTargetUserId.get(item.fromUserId);
 
         return {
           id: `received-${item.heartId}`,
@@ -369,29 +358,17 @@ function mapReceivedHeartProfiles(
           name: item.fromUser.nickname,
           age: item.fromUser.age,
           location: getProfileLocation(item.fromUser),
-          image: item.fromUser.profileImageUrl,
-          isLiked: item.isLiked ?? likedHeartId != null,
+          image: item.fromUser.profileImageUrl || FALLBACK_PROFILE_IMAGE,
+          isLiked: likedHeartId != null,
         };
       }),
     ) ?? []
   );
 }
 
-function mapSentHeartProfiles(data?: {
-  pages: {
-    items: {
-      heartId: number;
-      targetUserId: number;
-      targetUser: {
-        nickname: string;
-        age: number;
-        areaName?: string | null;
-        area?: { name?: string | null } | null;
-        profileImageUrl: string;
-      };
-    }[];
-  }[];
-}): ScreenHeartProfile[] {
+function mapSentHeartProfiles(
+  data: { pages: IHeartsentResponse[] } | undefined,
+): ScreenHeartProfile[] {
   return (
     data?.pages.flatMap((page) =>
       page.items.map((item) => ({
@@ -401,17 +378,15 @@ function mapSentHeartProfiles(data?: {
         name: item.targetUser.nickname,
         age: item.targetUser.age,
         location: getProfileLocation(item.targetUser),
-        image: item.targetUser.profileImageUrl,
+        image: item.targetUser.profileImageUrl || FALLBACK_PROFILE_IMAGE,
         isLiked: true,
       })),
     ) ?? []
   );
 }
 
-function getProfileLocation(profile: {
-  areaName?: string | null;
-  area?: { name?: string | null } | null;
-}) {
+// 마음 응답의 상대 정보엔 지역이 없을 수 있음 — 서버가 주면 표시, 없으면 빈 값
+function getProfileLocation(profile: IProfileSummary) {
   return profile.areaName?.trim() || profile.area?.name?.trim() || "";
 }
 
@@ -494,9 +469,11 @@ function HeartProfileCard({
             <View style={styles.nameDot} />
             <Text style={styles.cardName}>{profile.age}세</Text>
           </View>
-          <Text style={styles.cardLocation} numberOfLines={1}>
-            {profile.location}
-          </Text>
+          {profile.location ? (
+            <Text style={styles.cardLocation} numberOfLines={1}>
+              {profile.location}
+            </Text>
+          ) : null}
         </View>
       </ImageBackground>
     </Pressable>

--- a/app/profile-detail.tsx
+++ b/app/profile-detail.tsx
@@ -655,12 +655,15 @@ function ProfileClubSection({
               {club.title}
             </Text>
             <Text style={styles.clubMeta} numberOfLines={1}>
-              {club.location} · {club.category}
+              {club.location ? `${club.location} · ${club.category}` : club.category}
             </Text>
-            <View style={styles.memberRow}>
-              <Ionicons name="person" size={18} color="#A6AFB6" />
-              <Text style={styles.memberText}>{club.memberLabel}</Text>
-            </View>
+            {/* 위치·인원은 프로필 응답에 없어 값이 있을 때만 표시 */}
+            {club.memberLabel ? (
+              <View style={styles.memberRow}>
+                <Ionicons name="person" size={18} color="#A6AFB6" />
+                <Text style={styles.memberText}>{club.memberLabel}</Text>
+              </View>
+            ) : null}
           </View>
         </View>
       ))}

--- a/app/profile-detail.tsx
+++ b/app/profile-detail.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/hooks/api/useSocials";
 import { useUserProfileQuery } from "@/hooks/api/useUsers";
 import type { ReportCategory } from "@/types/api/socials/socialsDTO";
-import type { IUserProfile } from "@/types/user";
+import type { IProfileClubSummary, IUserPublicProfile } from "@/types/user";
 
 const FALLBACK_PROFILE_IMAGE =
   "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?q=85&w=1200&auto=format&fit=crop";
@@ -162,14 +162,11 @@ export default function ProfileDetailScreen() {
   );
 
   useEffect(() => {
-    if (typeof profileQuery.data?.isLiked === "boolean") {
-      setLiked(profileQuery.data.isLiked);
+    // 공개 프로필 응답은 하트 발송 여부(hasSentHeart)만 제공 — heartId는 마음함 경유 params로만 확보
+    if (typeof profileQuery.data?.hasSentHeart === "boolean") {
+      setLiked(profileQuery.data.hasSentHeart);
     }
-
-    if (typeof profileQuery.data?.likedHeartId === "number") {
-      setCurrentHeartId(profileQuery.data.likedHeartId);
-    }
-  }, [profileQuery.data?.isLiked, profileQuery.data?.likedHeartId]);
+  }, [profileQuery.data?.hasSentHeart]);
 
   const getTargetUserId = () => {
     if (userId) return userId;
@@ -705,23 +702,33 @@ function mapParamsToProfile(params: ProfileDetailParams): ProfileViewData | null
 }
 
 function mapProfileToViewData(
-  profile: IUserProfile | undefined,
+  profile: IUserPublicProfile | undefined,
   fallback: ProfileViewData | null,
 ): ProfileViewData | null {
   if (!profile) return fallback;
 
   return {
     name: profile.nickname || fallback?.name || "프로필",
-    age: normalizeAge(profile.age, profile.birthDate) ?? fallback?.age ?? null,
+    age: normalizeAge(profile.age) ?? fallback?.age ?? null,
     location: profile.area?.name || fallback?.location || "",
     distance: fallback?.distance || "",
     intro: profile.introText || fallback?.intro || "",
     image: profile.profileImageUrl || fallback?.image || FALLBACK_PROFILE_IMAGE,
-    interests: profile.keywords ?? [],
+    interests: profile.interests ?? [],
     preferences: profile.idealPersonalities ?? [],
-    joinedClubs: fallback?.joinedClubs ?? [],
-    hostedClubs: fallback?.hostedClubs ?? [],
+    joinedClubs: mapProfileClubs(profile.participatingClubs),
+    hostedClubs: mapProfileClubs(profile.hostingClubs),
   };
+}
+
+function mapProfileClubs(clubs?: IProfileClubSummary[]): ProfileClub[] {
+  return (clubs ?? []).map((club) => ({
+    id: String(club.clubId),
+    title: club.name,
+    location: "",
+    category: club.category,
+    memberLabel: "",
+  }));
 }
 
 function normalizeAge(age?: number | string | null, birthDate?: string | null) {

--- a/types/api/socials/socialsDTO.ts
+++ b/types/api/socials/socialsDTO.ts
@@ -1,5 +1,5 @@
 export interface IProfileSummary {
-  profileImageUrl: string;
+  profileImageUrl: string | null;
   nickname: string;
   age: number;
   areaName?: string | null;

--- a/types/api/socials/socialsDTO.ts
+++ b/types/api/socials/socialsDTO.ts
@@ -1,10 +1,11 @@
 export interface IProfileSummary {
+  id?: number;
   profileImageUrl: string | null;
   nickname: string;
-  age: number;
-  areaName?: string | null;
-  area?: {
-    name?: string | null;
+  // 서버는 나이/지역을 birthdate·address로 내려줌 (age/areaName 아님)
+  birthdate?: string | null;
+  address?: {
+    fullName?: string | null;
   } | null;
 }
 

--- a/types/user.ts
+++ b/types/user.ts
@@ -18,3 +18,27 @@ export interface IUserProfile {
   isLiked?: boolean;
   likedHeartId?: number | null;
 }
+
+// 타인 공개 프로필 (GET /v1/users/{userId}/profile) — /users/me와 응답 스키마가 다름
+export interface IProfileClubSummary {
+  clubId: number;
+  name: string;
+  thumbnailUrl: string | null;
+  category: string;
+  introText: string | null;
+}
+
+export interface IUserPublicProfile {
+  userId: number;
+  nickname: string;
+  age: number;
+  gender: string;
+  area: { name: string };
+  introText: string;
+  interests: string[];
+  idealPersonalities: string[];
+  participatingClubs: IProfileClubSummary[];
+  hostingClubs: IProfileClubSummary[];
+  hasSentHeart: boolean;
+  profileImageUrl: string;
+}

--- a/utils/age.ts
+++ b/utils/age.ts
@@ -1,0 +1,18 @@
+// 생년월일(ISO 문자열)로 만 나이 계산. 유효하지 않으면 null.
+export function getAgeFromBirthdate(birthdate?: string | null): number | null {
+  if (!birthdate) return null;
+
+  const birthday = new Date(birthdate);
+  if (Number.isNaN(birthday.getTime())) return null;
+
+  const today = new Date();
+  let age = today.getFullYear() - birthday.getFullYear();
+  const birthdayThisYear = new Date(
+    today.getFullYear(),
+    birthday.getMonth(),
+    birthday.getDate(),
+  );
+  if (today < birthdayThisYear) age -= 1;
+
+  return age > 0 ? age : null;
+}


### PR DESCRIPTION
## 배경
`fix/EUM-45-club-updates`의 로컬 커밋 2개(`913d43d`, `c948e2a`)가 push 전에 PR #108이 머지되면서 dev에 누락됨. 재반영합니다.

## 포함 커밋
- `913d43d` fix: 프로필 상세/마음함 API 응답 스키마 정합
  - `getUserProfile` 경로 `/v1/users/{id}` → `/v1/users/{id}/profile` (404 해결)
  - `IUserPublicProfile` 신설 및 매핑 (interests/hasSentHeart/clubs)
- `c948e2a` fix: 마음함 카드 나이/거주지 표시 복구
  - 하트 목록 응답이 `birthdate`/`address.fullName`로 내려오는 실제 스키마에 맞춤
  - `getAgeFromBirthdate` 유틸 신설

🤖 Generated with [Claude Code](https://claude.com/claude-code)