### PR TITLE
알림 일자가 48시간 전으로 뜨는 문제 해결

### DIFF
--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -69,7 +69,12 @@ const formatRelativeTime = (timestamp: Date) => {
   }
 
   const diffHours = Math.floor(diffMinutes / 60);
-  return `${diffHours}시간전`;
+  if (diffHours < 24) {
+    return `${diffHours}시간전`;
+  }
+
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}일전`;
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## 📝 작업 내용
- 어떤 기능을 개발/수정했는지 요약해주세요.

## 🔍 관련 이슈
- #136 

## 🖼️ 스크린샷
- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.

## 🧪 테스트 결과
- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 알림 시간 표시가 더 자연스럽게 보이도록 개선되었습니다.
  * 24시간 미만은 기존처럼 “시간전”으로 표시하고, 그 이후에는 “일전”으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->