### PR TITLE
마음함과 프로필 상세 하트 상태가 다른 상태 해결

### DIFF
--- a/app/(tabs)/heart.tsx
+++ b/app/(tabs)/heart.tsx
@@ -1,4 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -17,6 +19,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 
 import { HeartCardGridSkeleton } from "@/components/skeletons";
+import { queryKeys } from "@/hooks/api/queryKeys";
 import {
   usePatchHeartMutation,
   useReceivedHeartsInfiniteQuery,
@@ -32,6 +35,7 @@ import type {
   IHeartsentResponse,
   IProfileSummary,
 } from "@/types/api/socials/socialsDTO";
+import type { IUserPublicProfile } from "@/types/user";
 import { uniqueBy } from "@/utils/array";
 
 const PINK = "#FF3E70";
@@ -64,6 +68,7 @@ type OptimisticHeartState = {
 
 export default function HeartScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { tab } = useLocalSearchParams<{ tab?: string }>();
   const { width } = useWindowDimensions();
   const [activeTab, setActiveTab] = useState<HeartTab>(
@@ -149,6 +154,23 @@ export default function HeartScreen() {
     });
   }, [activeQuery]);
 
+  const updateProfileHeartCache = useCallback(
+    (targetUserId: number, nextLiked: boolean, nextHeartId?: number) => {
+      queryClient.setQueryData<IUserPublicProfile | undefined>(
+        queryKeys.users.detail(targetUserId),
+        (current) =>
+          current
+            ? {
+                ...current,
+                hasSentHeart: nextLiked,
+                sentHeartId: nextHeartId ?? null,
+              }
+            : current,
+      );
+    },
+    [queryClient],
+  );
+
   useEffect(() => {
     setOptimisticHeartState((prev) => {
       const profilesByUserId = new Map<number, ScreenHeartProfile>();
@@ -215,7 +237,17 @@ export default function HeartScreen() {
           ...prev,
           [targetUserId]: previousState,
         }));
+        updateProfileHeartCache(
+          targetUserId,
+          previousState.isLiked,
+          previousState.likedHeartId,
+        );
       };
+      updateProfileHeartCache(
+        targetUserId,
+        nextLiked,
+        nextLiked ? profile.likedHeartId : undefined,
+      );
 
       if (profile.isLiked) {
         if (profile.likedHeartId == null) {
@@ -225,7 +257,16 @@ export default function HeartScreen() {
         }
 
         patchHeartMutation.mutate(profile.likedHeartId, {
-          onError: rollbackHeartState,
+          onError: (error) => {
+            if (isMissingHeartError(error)) {
+              void queryClient.invalidateQueries({
+                queryKey: queryKeys.socials.hearts.all(),
+              });
+              return;
+            }
+
+            rollbackHeartState();
+          },
           onSettled: resetPending,
         });
         return;
@@ -240,12 +281,19 @@ export default function HeartScreen() {
               likedHeartId: response.heartId,
             },
           }));
+          updateProfileHeartCache(targetUserId, true, response.heartId);
         },
         onError: rollbackHeartState,
         onSettled: resetPending,
       });
     },
-    [patchHeartMutation, pendingUserIds, sendHeartMutation],
+    [
+      patchHeartMutation,
+      pendingUserIds,
+      queryClient,
+      sendHeartMutation,
+      updateProfileHeartCache,
+    ],
   );
 
   return (
@@ -432,6 +480,14 @@ function mapSentHeartProfiles(
 
 function isPositiveUserId(userId: number | null): userId is number {
   return typeof userId === "number" && Number.isFinite(userId) && userId > 0;
+}
+
+function isMissingHeartError(error: unknown) {
+  return (
+    isAxiosError(error) &&
+    error.response?.status === 404 &&
+    error.response.data?.error?.code === "SOCIAL-005"
+  );
 }
 
 function getProfileAge(profile: IProfileSummary): number | null {

--- a/app/profile-detail.tsx
+++ b/app/profile-detail.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
@@ -32,6 +33,7 @@ import { DEFAULT_PROFILE_IMAGE_URI } from "@/constants/defaultProfileImage";
 import { KEYBOARD_AVOIDING_BEHAVIOR } from "@/constants/keyboard";
 import { useCreateChatRoomMutation } from "@/hooks/api/useChats";
 import { useFastInputScroll } from "@/hooks/useFastInputScroll";
+import { queryKeys } from "@/hooks/api/queryKeys";
 import {
   useBlockUserMutation,
   useBlocksInfiniteQuery,
@@ -41,7 +43,10 @@ import {
   useSendHeartMutation,
 } from "@/hooks/api/useSocials";
 import { useUserProfileQuery } from "@/hooks/api/useUsers";
-import type { ReportCategory } from "@/types/api/socials/socialsDTO";
+import type {
+  IHeartsentResponse,
+  ReportCategory,
+} from "@/types/api/socials/socialsDTO";
 import type { IProfileClubSummary, IUserPublicProfile } from "@/types/user";
 import { shareProfile } from "@/utils/shareLinks";
 
@@ -81,6 +86,9 @@ type ProfileClub = {
 
 const ENABLE_PROFILE_DETAIL_QUERY = true;
 const REPORT_MAX_LENGTH = 300;
+const SENT_HEARTS_QUERY_KEY = [...queryKeys.socials.hearts.all(), "sent"] as const;
+
+type SentHeartsInfiniteData = InfiniteData<IHeartsentResponse, string | null>;
 
 type ReportReason = {
   label: string;
@@ -123,6 +131,7 @@ const REPORT_REASONS: ReportReason[] = [
 
 export default function ProfileDetailScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const params = useLocalSearchParams<ProfileDetailParams>();
   const insets = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
@@ -162,11 +171,55 @@ export default function ProfileDetailScreen() {
   );
 
   useEffect(() => {
-    // 공개 프로필 응답은 하트 발송 여부(hasSentHeart)만 제공 — heartId는 마음함 경유 params로만 확보
     if (typeof profileQuery.data?.hasSentHeart === "boolean") {
       setLiked(profileQuery.data.hasSentHeart);
+      setCurrentHeartId(profileQuery.data.sentHeartId ?? null);
     }
-  }, [profileQuery.data?.hasSentHeart]);
+  }, [profileQuery.data?.hasSentHeart, profileQuery.data?.sentHeartId]);
+
+  const updateProfileHeartCache = (nextLiked: boolean, nextHeartId: number | null) => {
+    if (!userId) return;
+
+    queryClient.setQueryData<IUserPublicProfile | undefined>(
+      queryKeys.users.detail(userId),
+      (current) =>
+        current
+          ? {
+              ...current,
+              hasSentHeart: nextLiked,
+              sentHeartId: nextHeartId,
+            }
+          : current,
+    );
+  };
+
+  const removeSentHeartFromCache = (targetUserId: number) => {
+    queryClient.setQueriesData<SentHeartsInfiniteData>(
+      { queryKey: SENT_HEARTS_QUERY_KEY },
+      (current) => {
+        if (!current) return current;
+
+        return {
+          ...current,
+          pages: current.pages.map((page) => {
+            const items = page.items.filter(
+              (item) => item.targetUserId !== targetUserId,
+            );
+            const removedCount = page.items.length - items.length;
+
+            return {
+              ...page,
+              items,
+              totalCount:
+                typeof page.totalCount === "number"
+                  ? Math.max(0, page.totalCount - removedCount)
+                  : page.totalCount,
+            };
+          }),
+        };
+      },
+    );
+  };
 
   const getTargetUserId = () => {
     if (userId) return userId;
@@ -187,22 +240,52 @@ export default function ProfileDetailScreen() {
         return;
       }
 
-      patchHeartMutation.mutate(currentHeartId, {
-        onSuccess: () => {
-          setLiked(false);
-          setCurrentHeartId(null);
+      const previousHeartId = currentHeartId;
+      const previousSentHearts =
+        queryClient.getQueriesData<SentHeartsInfiniteData>({
+          queryKey: SENT_HEARTS_QUERY_KEY,
+        });
+      setLiked(false);
+      setCurrentHeartId(null);
+      updateProfileHeartCache(false, null);
+      removeSentHeartFromCache(targetUserId);
+
+      patchHeartMutation.mutate(previousHeartId, {
+        onError: (error) => {
+          if (isMissingHeartError(error)) {
+            void queryClient.invalidateQueries({
+              queryKey: queryKeys.socials.hearts.all(),
+            });
+            return;
+          }
+
+          setLiked(true);
+          setCurrentHeartId(previousHeartId);
+          updateProfileHeartCache(true, previousHeartId);
+          previousSentHearts.forEach(([queryKey, data]) => {
+            queryClient.setQueryData(queryKey, data);
+          });
+          Alert.alert("처리 실패", "마음 상태를 변경하지 못했어요.");
         },
-        onError: () => Alert.alert("처리 실패", "마음 상태를 변경하지 못했어요."),
       });
       return;
     }
 
+    setLiked(true);
+    setCurrentHeartId(null);
+    updateProfileHeartCache(true, null);
+
     sendHeartMutation.mutate(targetUserId, {
       onSuccess: (response) => {
-        setLiked(true);
         setCurrentHeartId(response.heartId);
+        updateProfileHeartCache(true, response.heartId);
       },
-      onError: () => Alert.alert("처리 실패", "마음을 보내지 못했어요."),
+      onError: () => {
+        setLiked(false);
+        setCurrentHeartId(null);
+        updateProfileHeartCache(false, null);
+        Alert.alert("처리 실패", "마음을 보내지 못했어요.");
+      },
     });
   };
 
@@ -804,6 +887,11 @@ function getApiErrorDetail(error: unknown) {
     code: error.code ?? "",
     message: error.message,
   };
+}
+
+function isMissingHeartError(error: unknown) {
+  const apiError = getApiErrorDetail(error);
+  return apiError.code === "SOCIAL-005";
 }
 
 function isApiErrorPayload(

--- a/types/user.ts
+++ b/types/user.ts
@@ -40,5 +40,6 @@ export interface IUserPublicProfile {
   participatingClubs: IProfileClubSummary[];
   hostingClubs: IProfileClubSummary[];
   hasSentHeart: boolean;
+  sentHeartId: number | null;
   profileImageUrl: string;
 }


### PR DESCRIPTION
## 📝 작업 내용
- 프로필 상세 api에 새로 추가된 sentHeartId를 반영
- 프로필 상세 집인 시 hassentHeart와 sentHeratId를 기준으로 동기화
- 프로필 상세 하트 보내기에 낙관적 업데이트 적용
- 마음함 미니 카드 상태도 하트 전송이나 해제시에 캐시를 갱신하도록 수정 -> 마음함 수정이 프로필 상세에 적용되지 않던 근본적인 문제 해결
- stale heartId로 PATCH가 재시도되며 하트가 다시 켜지는 문제를 방지합니다.
## 🔍 관련 이슈
- closes #120

## 🧪 테스트 결과
- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.
-## 변경 요약

