### PR TITLE
fix: 온보딩 홈 진입 가드, 동호회 생성 경고 모달, 수동 새로고침, 내 동호회 상태 필터 (EUM-109)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -6,10 +6,11 @@ import { StyleSheet, View } from "react-native";
 import { AppNavbar } from "@/components/AppNavbar";
 import { queryKeys } from "@/hooks/api/queryKeys";
 
+// 홈 추천(recommendations)은 1시간 유지 정책이라 탭 전환 invalidate 대상에서 제외한다.
+// (홈의 카운트다운 만료와 하트 전송 뮤테이션만 추천을 갱신한다)
 const TAB_REFRESH_QUERY_KEYS = {
   index: [
     queryKeys.users.me(),
-    queryKeys.recommendations.all,
     queryKeys.notifications.all,
     queryKeys.club.all,
   ],
@@ -18,7 +19,6 @@ const TAB_REFRESH_QUERY_KEYS = {
   my: [
     queryKeys.users.me(),
     queryKeys.socials.hearts.all(),
-    queryKeys.recommendations.all,
     queryKeys.club.my(),
   ],
 } as const;

--- a/app/(tabs)/my.tsx
+++ b/app/(tabs)/my.tsx
@@ -1,8 +1,10 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
+import { useCallback, useState } from "react";
 import {
   Alert,
   Image,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   Switch,
@@ -45,6 +47,20 @@ export default function MyTabScreen() {
   const myClubsQuery = useMyClubsQuery();
   const logoutMutation = useLogoutMutation();
   const deactivateUserMutation = useDeactivateUserMutation();
+  const [isPullRefreshing, setIsPullRefreshing] = useState(false);
+
+  // 홈 추천(recommendations)은 1시간 유지 정책이라 수동 새로고침 대상에서 제외한다.
+  const handleRefresh = useCallback(() => {
+    setIsPullRefreshing(true);
+    void Promise.allSettled([
+      myProfileQuery.refetch(),
+      receivedHeartsQuery.refetch(),
+      myClubsQuery.refetch(),
+    ]).finally(() => {
+      setIsPullRefreshing(false);
+    });
+  }, [myClubsQuery, myProfileQuery, receivedHeartsQuery]);
+
   const profile = myProfileQuery.data;
   const receivedHeartCount =
     receivedHeartsQuery.data?.pages.reduce(
@@ -59,10 +75,13 @@ export default function MyTabScreen() {
       0,
     ) ?? (recommendationsQuery.isSuccess ? 0 : undefined);
   // ponytail: 엔드포인트에 페이지네이션이 없어 slice로 기존 5개 노출 유지
+  // 마이페이지는 가입 확정(ACTIVE)만 표시. status가 없는 응답(구버전)은 확정으로 간주.
   const myClubs = uniqueBy(
     myClubsQuery.data?.items ?? [],
     (item) => item.clubId,
-  ).slice(0, 5);
+  )
+    .filter((item) => !item.status || item.status === "ACTIVE")
+    .slice(0, 5);
 
   const handleNotificationToggle = (enabled: boolean) => {
     setNotificationEnabled(enabled);
@@ -104,6 +123,14 @@ export default function MyTabScreen() {
         contentInsetAdjustmentBehavior="automatic"
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={isPullRefreshing}
+            onRefresh={handleRefresh}
+            tintColor={ACCENT}
+            colors={[ACCENT]}
+          />
+        }
       >
         <Text style={styles.screenTitle}>마이페이지</Text>
 
@@ -228,6 +255,7 @@ export default function MyTabScreen() {
                 key={club.clubId}
                 title={club.name || "이름 없는 동호회"}
                 subtitle={`${club.authority === "HOST" ? "동호회장" : "멤버"} · 멤버 ${club.memberCount ?? 0}명`}
+                image={club.thumbnailUrl}
                 variant={index % 2 === 0 ? "running" : "mountain"}
                 onPress={() =>
                   router.push({
@@ -295,11 +323,13 @@ export default function MyTabScreen() {
 function ClubRow({
   title,
   subtitle,
+  image,
   variant,
   onPress,
 }: {
   title: string;
   subtitle: string;
+  image?: string | null;
   variant: "running" | "mountain";
   onPress: () => void;
 }) {
@@ -311,7 +341,10 @@ function ClubRow({
           variant === "running" ? styles.runningThumb : styles.mountainThumb,
         ]}
       >
-        {variant === "running" ? (
+        {/* API 썸네일 우선, 없을 때만 기존 일러스트 fallback */}
+        {image ? (
+          <Image source={{ uri: image }} style={styles.clubThumbImage} />
+        ) : variant === "running" ? (
           <>
             <Ionicons name="walk" size={16} color="#5E321E" />
             <View style={styles.runnerDot} />
@@ -578,6 +611,10 @@ const styles = StyleSheet.create({
     marginRight: 12,
     overflow: "hidden",
     borderRadius: 6,
+  },
+  clubThumbImage: {
+    width: "100%",
+    height: "100%",
   },
   runningThumb: {
     backgroundColor: "#EFD7BA",

--- a/app/club/create.tsx
+++ b/app/club/create.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   LayoutChangeEvent,
+  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -57,6 +58,8 @@ export default function ClubCreateScreen() {
   const [boardScope, setBoardScope] = useState<BoardScope>("member");
   const [coverImages, setCoverImages] = useState<CoverImage[]>([]);
   const [isUploadingCover, setUploadingCover] = useState(false);
+  // 정치·종교·포교 금지 안내 — 화면 진입 시 1회만 노출 (영구 저장 없이 컴포넌트 state 기준)
+  const [showPolicyNotice, setShowPolicyNotice] = useState(true);
   const areaCode = useClubCreateAreaStore((state) => state.areaCode);
   const areaName = useClubCreateAreaStore((state) => state.areaName);
 
@@ -372,6 +375,33 @@ export default function ClubCreateScreen() {
           labelStyle={styles.ctaLabel}
         />
       </KeyboardAvoidingView>
+
+      {/* 정치·종교·포교 금지 경고 모달 */}
+      <Modal
+        visible={showPolicyNotice}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowPolicyNotice(false)}
+      >
+        <View style={styles.noticeOverlay}>
+          <View style={styles.noticeCard}>
+            <Text style={styles.noticeTitle}>동호회 운영 안내</Text>
+            <Text style={styles.noticeDescription}>
+              정치·종교·포교 목적의 동호회 생성 및 활동이 적발될 경우 서비스
+              이용 제한 및 손해배상 청구 대상이 될 수 있습니다.
+            </Text>
+            <Pressable
+              style={({ pressed }) => [
+                styles.noticeButton,
+                pressed && styles.noticeButtonPressed,
+              ]}
+              onPress={() => setShowPolicyNotice(false)}
+            >
+              <Text style={styles.noticeButtonText}>확인</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -746,5 +776,52 @@ const styles = StyleSheet.create({
     fontSize: 18,
     lineHeight: 23,
     fontWeight: "600",
+  },
+  // 정치·종교·포교 금지 경고 모달 (AgeRestrictionModal 톤)
+  noticeOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 40,
+  },
+  noticeCard: {
+    width: "100%",
+    backgroundColor: "#FFFFFF",
+    borderRadius: 20,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 24,
+    alignItems: "center",
+  },
+  noticeTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#1F2937",
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  noticeDescription: {
+    fontSize: 14,
+    color: "#6B7280",
+    lineHeight: 20,
+    textAlign: "center",
+    marginBottom: 24,
+  },
+  noticeButton: {
+    width: "100%",
+    height: 52,
+    backgroundColor: "#FF3E70",
+    borderRadius: 14,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  noticeButtonPressed: {
+    opacity: 0.85,
+  },
+  noticeButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FFFFFF",
   },
 });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,12 +1,14 @@
 import { Redirect } from "expo-router";
 
 import { useAuthStore } from "@/stores/authStore";
+import { useOnboardingDraftStore } from "@/stores/onboardingDraftStore";
 
 export default function Index() {
   const isAuthInitialized = useAuthStore((state) => state.isAuthInitialized);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const isNewUser = useAuthStore((state) => state.isNewUser);
   const onboardingRequired = useAuthStore((state) => state.onboardingRequired);
+  const vibeVector = useOnboardingDraftStore((state) => state.vibeVector);
 
   if (!isAuthInitialized) {
     return null;
@@ -16,9 +18,12 @@ export default function Index() {
     return <Redirect href="/auth" />;
   }
 
+  // 온보딩 대상(신규/미완료)인데 음성분석(vibeVector)까지 마치지 못했으면 홈 진입을 막는다.
+  // vibeVector는 보조 기준 — 기존 가입자(플래그 false)는 vibeVector가 없어도 홈으로 간다.
+  const needsOnboarding =
+    (onboardingRequired || isNewUser) && vibeVector.length === 0;
+
   return (
-    <Redirect
-      href={onboardingRequired || isNewUser ? "/onboarding/permissions" : "/(tabs)"}
-    />
+    <Redirect href={needsOnboarding ? "/onboarding/permissions" : "/(tabs)"} />
   );
 }

--- a/components/chat/ChatListScreen.tsx
+++ b/components/chat/ChatListScreen.tsx
@@ -2,12 +2,13 @@ import { Ionicons } from "@expo/vector-icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { Image } from "expo-image";
 import { useRouter } from "expo-router";
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   FlatList,
   ListRenderItem,
   Pressable,
+  RefreshControl,
   StyleSheet,
   Text,
   View,
@@ -48,6 +49,14 @@ export default function ChatListScreen() {
   );
   const chatPreviews = apiChatPreviews;
   const isInitialLoading = chatRoomsQuery.isLoading && chatPreviews.length === 0;
+  const [isPullRefreshing, setIsPullRefreshing] = useState(false);
+
+  const handleRefresh = useCallback(() => {
+    setIsPullRefreshing(true);
+    void chatRoomsQuery.refetch().finally(() => {
+      setIsPullRefreshing(false);
+    });
+  }, [chatRoomsQuery]);
 
   const openChatRoom = (item: ChatPreview) => {
     const chatRoomId = Number(item.id);
@@ -144,6 +153,14 @@ export default function ChatListScreen() {
         keyExtractor={(item) => item.id}
         renderItem={renderChatPreview}
         ListHeaderComponent={renderHeader}
+        refreshControl={
+          <RefreshControl
+            refreshing={isPullRefreshing}
+            onRefresh={handleRefresh}
+            tintColor="#FF3E70"
+            colors={["#FF3E70"]}
+          />
+        }
         ListEmptyComponent={
           isInitialLoading ? (
             <ChatPreviewListSkeleton />

--- a/components/home/HomeScreen.tsx
+++ b/components/home/HomeScreen.tsx
@@ -724,9 +724,14 @@ function ClubHomeContent({
   const myClubsQuery = useMyClubsQuery();
   const todayRecommendedQuery = useTodayRecommendedClubsQuery(10);
 
+  // 가입 확정(ACTIVE) + 가입 대기(PENDING)만 내 동호회로 표시.
+  // 거절/강퇴/탈퇴(REJECTED/KICKED/LEFT)는 제외하고, status 없는 응답(구버전)은 포함한다.
   const myClubs = uniqueBy(
     myClubsQuery.data?.items ?? [],
     (item) => item.clubId,
+  ).filter(
+    (item) =>
+      !item.status || item.status === "ACTIVE" || item.status === "PENDING",
   );
   // 펼친 그리드: 3열 고정. 작은 화면에서는 카드 폭을 줄이고, 남는 폭은 열 간격으로 배분해
   // 마지막 행이 1~2개여도 왼쪽부터 같은 간격으로 정렬되게 한다.
@@ -767,7 +772,6 @@ function ClubHomeContent({
         ) : null}
       </View>
 
-      {/* ponytail: my-clubs API에 가입대기(PENDING) 정보가 없어 status 배지 미표시 — 서버 추가 시 복원 */}
       {myClubsQuery.isLoading ? (
         <MyClubCardListSkeleton />
       ) : showAllMyClubs ? (
@@ -783,6 +787,7 @@ function ClubHomeContent({
                   key={club.clubId}
                   title={club.name}
                   image={club.thumbnailUrl}
+                  status={club.status === "PENDING" ? "가입 대기중" : undefined}
                   cardWidth={myClubCardWidth}
                   onPress={() => onOpenClub(String(club.clubId))}
                 />
@@ -801,6 +806,7 @@ function ClubHomeContent({
               key={club.clubId}
               title={club.name}
               image={club.thumbnailUrl}
+              status={club.status === "PENDING" ? "가입 대기중" : undefined}
               onPress={() => onOpenClub(String(club.clubId))}
             />
           ))}


### PR DESCRIPTION
## 📝 작업 내용
- **온보딩 미완료 홈 진입 방지**: `app/index.tsx` 라우팅 가드에 조건 추가 — 로그인됨 && (`onboardingRequired` || `isNewUser`) && `vibeVector` 없음이면 홈 대신 `/onboarding/permissions`로 redirect. vibeVector는 보조 기준이라 기존 가입자(플래그 false)는 영향 없음
- **동호회 생성 경고 모달**: 생성 화면 진입 시 "정치·종교·포교 목적의 동호회 생성 및 활동이 적발될 경우 서비스 이용 제한 및 손해배상 청구 대상이 될 수 있습니다" 모달 1회 노출 (기존 AgeRestrictionModal 톤, 확인 버튼)
- **수동 새로고침 추가**: 채팅 목록·마이페이지에 pull-to-refresh 추가 (기존 heart.tsx 패턴 재사용). 홈 추천은 1시간 유지 정책이라 새로고침 대상에서 제외했고, 탭 전환 invalidate 목록에서도 추천 쿼리를 제거해 정책 위반 경로를 없앰
- **내 동호회 상태 필터**:
  - 동호회 홈: `ACTIVE`+`PENDING`만 표시 + PENDING에 "가입 대기중" 배지, 거절/강퇴/탈퇴 제외
  - 마이페이지: `ACTIVE`만 표시 + API 썸네일 우선 적용(없을 때만 기존 일러스트 fallback)
  - 기준: `ClubMemberStatus` enum allowlist, status 없는 응답(구버전)은 기존 동작 유지

## 🔍 관련 이슈
- EUM-109

## 🖼️ 스크린샷
- 로직 수정 위주라 캡처 생략 — 아래 테스트 시나리오로 확인 가능합니다

## 🧪 테스트 결과
- [x] 정상 작동 확인 (pnpm lint 에러 0 / tsc --noEmit 통과)
- [ ] 테스트 코드 포함 (있다면)

수동 확인 시나리오:
1. 온보딩 도중(음성분석 전) 홈 이동 시도 → 온보딩으로 돌아가는지
2. 동호회 만들기 진입 → 경고 모달 1회 노출 → 확인 후 정상 작성
3. 채팅 목록/마이페이지 아래로 당겨 새로고침
4. 가입 대기중 동호회가 동호회 홈에 배지와 함께 보이고, 마이페이지에는 안 보이는지
5. 마이페이지 내 동호회 썸네일 표시

## 💬 기타 참고 사항
- authStore가 비영속이라 **앱 프로세스 완전 종료 후 재진입(콜드 스타트)** 케이스는 이 가드로 못 잡습니다 (플래그가 false로 초기화됨). API 추가 금지 조건이라 서버 온보딩 상태 조회 없이는 한계 — 후속 논의 필요
- "가입 대기중이 홈에 안 보인다"는 증상은 서버가 my-clubs 응답에 PENDING 항목을 포함해야 완전히 해결됩니다. 프론트는 준비 완료
- origin/dev(#173) 머지 포함, ChatListScreen 충돌은 양쪽 기능(채팅 필터 탭 + pull-to-refresh) 모두 유지로 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 홈, 내 동호회, 채팅 목록에서 당겨서 새로고침을 지원합니다.
  * 동호회 생성 화면 진입 시 정책 안내 모달이 표시됩니다.
  * 내 동호회 카드에서 대기 중 상태를 더 명확히 보여줍니다.

* **Bug Fixes**
  * 탭 전환 시 일부 추천 데이터가 불필요하게 다시 갱신되던 동작을 조정했습니다.
  * 온보딩 진행 여부 판단이 더 정확해졌습니다.
  * 내 동호회 목록에서 상태가 없는 기존 데이터도 정상 표시되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->