### PR TITLE
fix: 알림 이동 및 홈 추천 카드 동작 수정

### DIFF
--- a/app/(tabs)/heart.tsx
+++ b/app/(tabs)/heart.tsx
@@ -69,7 +69,10 @@ type OptimisticHeartState = {
 export default function HeartScreen() {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { tab } = useLocalSearchParams<{ tab?: string }>();
+  const { tab, tabPressAt } = useLocalSearchParams<{
+    tab?: string;
+    tabPressAt?: string;
+  }>();
   const { width } = useWindowDimensions();
   const [activeTab, setActiveTab] = useState<HeartTab>(
     tab === "sent" ? "sent" : "received",
@@ -122,9 +125,11 @@ export default function HeartScreen() {
   const isInitialLoading = activeQuery.isLoading && profiles.length === 0;
   const receivedCount = receivedProfiles.length;
 
+  // 화면이 이미 mount된 상태에서 같은 tab 값으로 재진입해도(연속 "마음에들어요")
+  // tabPressAt이 매번 바뀌므로 다시 적용된다. navbar 탭 클릭은 tab 없이 와서 통과.
   useEffect(() => {
     if (tab === "sent" || tab === "received") setActiveTab(tab);
-  }, [tab]);
+  }, [tab, tabPressAt]);
 
   // 마음함이 포커스되면 현재까지 받은 마음을 읽음 처리해 navbar dot을 끈다.
   const markHeartsSeen = useHeartBadgeStore((state) => state.markHeartsSeen);

--- a/components/home/HomeScreen.tsx
+++ b/components/home/HomeScreen.tsx
@@ -196,9 +196,11 @@ export default function HomePage() {
   const sendHeartMutation = useSendRecommendationHeartMutation();
   const createProfileVisitMutation = useCreateProfileVisitMutation();
 
+  // 추천 스코프가 "나와 같은 지역"이라, 추천 응답에 지역이 없으면 내 지역을 fallback으로 쓴다.
+  const myAreaName = myProfileQuery.data?.area?.name?.trim() ?? "";
   const recommendedProfiles = useMemo(
-    () => mapRecommendationProfiles(recommendationsQuery.data),
-    [recommendationsQuery.data],
+    () => mapRecommendationProfiles(recommendationsQuery.data, myAreaName),
+    [recommendationsQuery.data, myAreaName],
   );
   const visitors = visitorsQuery.data?.items ?? [];
   const heartUnreadCount = useMemo(
@@ -325,9 +327,10 @@ export default function HomePage() {
     if (selectedProfile.targetUserId && !selectedProfile.isLiked) {
       sendHeartMutation.mutate(selectedProfile.targetUserId);
     }
+    // 같은 tab=sent로 재진입해도 전환되게, navbar와 같은 tabPressAt(매번 변경) param을 함께 넘긴다.
     router.replace({
       pathname: "/(tabs)/heart",
-      params: { tab: "sent" },
+      params: { tab: "sent", tabPressAt: String(Date.now()) },
     } as never);
   };
 
@@ -620,24 +623,27 @@ function countUnreadNotifications(data?: {
   );
 }
 
-function mapRecommendationProfiles(data?: {
-  pages?: {
-    items: {
-      userId: number;
-      nickname: string;
-      age: number;
-      // 서버가 평면(areaName)과 중첩(area.name) 두 형태로 지역을 내려줘 둘 다 지원한다.
-      areaName?: string | null;
-      area?: { name?: string | null } | null;
-      addressName?: string | null;
-      address?: { fullName?: string | null; name?: string | null } | null;
-      introText: string;
-      profileImageUrl: string;
-      isLiked: boolean;
-      likedHeartId: number | null;
+function mapRecommendationProfiles(
+  data?: {
+    pages?: {
+      items: {
+        userId: number;
+        nickname: string;
+        age: number;
+        // 서버가 평면(areaName)과 중첩(area.name) 두 형태로 지역을 내려줘 둘 다 지원한다.
+        areaName?: string | null;
+        area?: { name?: string | null } | null;
+        addressName?: string | null;
+        address?: { fullName?: string | null; name?: string | null } | null;
+        introText: string;
+        profileImageUrl: string;
+        isLiked: boolean;
+        likedHeartId: number | null;
+      }[];
     }[];
-  }[];
-}): Profile[] {
+  },
+  fallbackLocation = "",
+): Profile[] {
   return (
     uniqueBy(
       data?.pages?.flatMap((page) =>
@@ -646,7 +652,7 @@ function mapRecommendationProfiles(data?: {
           targetUserId: item.userId,
           name: item.nickname,
           age: item.age,
-          location: getProfileLocation(item),
+          location: getProfileLocation(item) || fallbackLocation,
           intro: item.introText,
           isLiked: item.isLiked,
           likedHeartId: item.likedHeartId,

--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -1,3 +1,4 @@
+import * as Notifications from "expo-notifications";
 import { useEffect } from "react";
 
 import { useAuthStore } from "@/stores/authStore";
@@ -7,6 +8,7 @@ import {
   onForegroundMessage,
   onNotificationOpened,
   onPushTokenRefresh,
+  openPushNotification,
   presentForegroundMessage,
   removePushTokenFromServer,
   syncPushTokenToServer,
@@ -24,21 +26,29 @@ export function usePushNotifications() {
     const unsubscribeMessage = onForegroundMessage((remoteMessage) => {
       void presentForegroundMessage(remoteMessage);
     });
-    // 백그라운드에서 알림 탭 → 앱 열림
+    // 백그라운드에서 알림 탭 → 앱 열림 → payload 기준 라우팅
     const unsubscribeOpened = onNotificationOpened((message) => {
-      console.log("[push] 알림 탭:", message.notification);
-      // TODO: 알림 payload(data.type 등) 기준 딥링크 라우팅
+      openPushNotification(message.data);
     });
     // 앱이 완전히 종료된 상태에서 알림으로 실행된 경우
     void getInitialPushNotification().then((message) => {
       if (!message) return;
-      console.log("[push] 종료상태에서 알림으로 열림:", message.notification);
-      // TODO: 딥링크 라우팅
+      // ponytail: 인증 초기화·초기 Redirect가 끝난 뒤 이동하도록 지연으로 회피 —
+      // 콜드스타트에서 목적지 유실이 재발하면 pending-link 저장 방식으로 승격
+      setTimeout(() => openPushNotification(message.data), 1500);
     });
+    // 포그라운드에서 로컬 알림으로 표시한 것을 탭한 경우
+    const responseSubscription =
+      Notifications.addNotificationResponseReceivedListener((response) => {
+        openPushNotification(
+          response.notification.request.content.data as Record<string, unknown>,
+        );
+      });
 
     return () => {
       unsubscribeMessage?.();
       unsubscribeOpened?.();
+      responseSubscription.remove();
     };
   }, []);
 

--- a/utils/pushNotifications.ts
+++ b/utils/pushNotifications.ts
@@ -1,9 +1,11 @@
 import type { FirebaseMessagingTypes } from "@react-native-firebase/messaging";
 import * as Application from "expo-application";
 import * as Notifications from "expo-notifications";
+import { router } from "expo-router";
 import { PermissionsAndroid, Platform } from "react-native";
 
 import {
+  readNotification,
   registerPushToken,
   unregisterPushToken,
 } from "@/api/notifications/notificationsApi";
@@ -142,6 +144,81 @@ export async function presentForegroundMessage(
     },
     trigger: null,
   });
+}
+
+export type PushRoute = { pathname: string; params: Record<string, string> };
+
+// FCM data 값은 전부 string으로 올 수 있어, 양의 정수로 검증된 값만 라우트 param으로 쓴다.
+function toId(value: unknown): string | null {
+  const num = Number(value);
+  return Number.isInteger(num) && num > 0 ? String(num) : null;
+}
+
+// FCM payload.data → 이동할 라우트. 목적지를 못 만들면 null(호출부에서 알림함 fallback).
+export function getRouteFromPushData(
+  data: Record<string, unknown> | undefined,
+): PushRoute | null {
+  if (!data) return null;
+
+  const type = String(data.type ?? "");
+  const chatRoomId = toId(data.chatRoomId);
+  const senderUserId = toId(data.senderUserId);
+  const clubId = toId(data.clubId);
+  const articleId = toId(data.articleId);
+  const heartId = toId(data.heartId);
+
+  if (type === "CHAT" && chatRoomId) {
+    return { pathname: "/chat/[id]", params: { id: chatRoomId } };
+  }
+  if (type === "HEART" && senderUserId) {
+    return {
+      pathname: "/profile-detail",
+      params: { userId: senderUserId, ...(heartId ? { heartId } : {}) },
+    };
+  }
+  if ((type === "ARTICLE" || type === "COMMENT") && clubId && articleId) {
+    return {
+      pathname: "/club/post-detail",
+      params: { clubId, postId: articleId },
+    };
+  }
+  if (type === "CLUB" && clubId) {
+    // 승인/거절(status)·동호회 신고(reportCount)는 상세로, 그 외(가입 신청)는 멤버 관리로.
+    const toDetail = data.status != null || data.reportCount != null;
+    return {
+      pathname: toDetail ? "/club/detail" : "/club/manage-members",
+      params: { clubId },
+    };
+  }
+  // ponytail: CLUB 게시글 신고(clubId 없이 articleId만) 포함, 목적지 불명은 전부 알림함으로
+  return null;
+}
+
+let lastOpenedKey = "";
+let lastOpenedAt = 0;
+
+// 알림 탭 공통 처리: notificationId 읽음 처리 + 라우팅.
+// RNFB/expo-notifications 리스너가 같은 탭에 중복 발화할 수 있어 2초 dedupe.
+export function openPushNotification(
+  data: Record<string, unknown> | undefined,
+): void {
+  const key = JSON.stringify(data ?? {});
+  const now = Date.now();
+  if (key === lastOpenedKey && now - lastOpenedAt < 2000) return;
+  lastOpenedKey = key;
+  lastOpenedAt = now;
+
+  const notificationId = toId(data?.notificationId);
+  if (notificationId) {
+    void readNotification(notificationId).catch(() => {});
+  }
+
+  const route = getRouteFromPushData(data);
+  if (route) {
+    router.push({ pathname: route.pathname, params: route.params } as never);
+  } else {
+    router.push("/notifications" as never);
+  }
 }
 
 // 로그인/알림 ON/토큰 갱신 시: 현재 FCM 토큰을 서버에 등록·갱신한다.


### PR DESCRIPTION
## 📝 작업 내용
- FCM 알림 클릭 시 payload data 기준으로 채팅, 프로필, 게시글, 동호회 화면으로 이동하도록 처리했습니다.
- 백그라운드/종료 상태/포그라운드 로컬 알림 클릭 경로를 공통 라우팅 함수로 연결했습니다.
- 홈 추천 프로필 카드의 지역 정보가 비어 있으면 내 거주지를 fallback으로 표시하도록 수정했습니다.
- 홈 추천 카드에서 마음을 보내면 마음함의 보낸 마음 탭으로 이동하도록 보정했습니다.

## 🔍 관련 이슈
- closes #184 

## 🧪 테스트 결과
- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- pnpm lint 통과했습니다. 기존 components/KeyboardCompat.tsx의 require import warning 1건은 이번 변경 범위 밖입니다.
- app.json의 iOS buildNumber 변경은 PR 범위에서 제외하고 로컬 변경으로 남겨두었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 푸시 알림 탭 시 관련 화면으로 바로 이동하도록 개선했습니다.
  * 알림 상세로 이동할 때 읽음 처리가 함께 반영됩니다.
  * 동일한 탭을 연속으로 눌러도 화면 전환이 다시 동작하도록 개선했습니다.
  * 추천 프로필에 지역명이 없을 때 내 지역명으로 보완해 더 자연스럽게 표시됩니다.

* **Bug Fixes**
  * 백그라운드, 종료 상태, 포그라운드 알림 응답 처리 흐름을 통합해 알림 열기 동작을 더 안정적으로 만들었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->