### PR TITLE
feat: 동호회 댓글 신고 API 연동

### DIFF
--- a/api/socials/socialsApi.ts
+++ b/api/socials/socialsApi.ts
@@ -153,3 +153,19 @@ export const createArticleReport = async (
   >(`/v1/report/clubs/${clubId}/articles/${articleId}`, body);
   return data.success.data;
 };
+
+// 동호회 게시글 댓글 신고하기 (POST)
+export const createCommentReport = async (
+  clubId: number,
+  articleId: number,
+  commentId: number,
+  body: DTO.IClubReportRequest,
+) => {
+  const { data } = await api.post<
+    ApiSuccessResponse<DTO.IClubReportResponse>
+  >(
+    `/v1/report/clubs/${clubId}/articles/${articleId}/comments/${commentId}`,
+    body,
+  );
+  return data.success.data;
+};

--- a/app/club/post-detail.tsx
+++ b/app/club/post-detail.tsx
@@ -422,8 +422,16 @@ export default function ClubPostDetailScreen() {
       return;
     }
 
+    const commentId = selectedComment.commentId;
     setSelectedComment(null);
-    Alert.alert("준비 중", "댓글 신고 API 명세 확인 후 연결 예정입니다.");
+    router.push({
+      pathname: "/club/report",
+      params: {
+        clubId: String(clubId),
+        articleId: String(postId),
+        commentId: String(commentId),
+      },
+    } as never);
   };
 
   const handleCommentSecondaryAction = () => {

--- a/app/club/report.tsx
+++ b/app/club/report.tsx
@@ -14,6 +14,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import {
   useCreateArticleReportMutation,
   useCreateClubReportMutation,
+  useCreateCommentReportMutation,
 } from "@/hooks/api/useSocials";
 import type { ReportCategory } from "@/types/api/socials/socialsDTO";
 
@@ -57,27 +58,37 @@ const REPORT_REASONS: ReportReason[] = [
 ];
 
 /**
- * 동호회 / 동호회 게시글 신고 화면
- * - articleId가 있으면 게시글 신고, 없으면 동호회 자체 신고로 동작합니다.
+ * 동호회 / 동호회 게시글 / 댓글 신고 화면
+ * - commentId가 있으면 댓글 신고, articleId만 있으면 게시글 신고, 둘 다 없으면 동호회 자체 신고로 동작합니다.
  */
 export default function ClubReportScreen() {
   const router = useRouter();
   const params = useLocalSearchParams<{
     clubId?: string;
     articleId?: string;
+    commentId?: string;
   }>();
   const clubId = parsePositiveInt(params.clubId);
   const articleId = parsePositiveInt(params.articleId);
-  const isArticleReport = articleId !== null;
+  const commentId = parsePositiveInt(params.commentId);
+  const isCommentReport = commentId !== null;
+  const isArticleReport = !isCommentReport && articleId !== null;
 
   const clubReportMutation = useCreateClubReportMutation(clubId ?? 0);
   const articleReportMutation = useCreateArticleReportMutation(
     clubId ?? 0,
     articleId ?? 0,
   );
-  const activeMutation = isArticleReport
-    ? articleReportMutation
-    : clubReportMutation;
+  const commentReportMutation = useCreateCommentReportMutation(
+    clubId ?? 0,
+    articleId ?? 0,
+    commentId ?? 0,
+  );
+  const activeMutation = isCommentReport
+    ? commentReportMutation
+    : isArticleReport
+      ? articleReportMutation
+      : clubReportMutation;
 
   const [selectedReason, setSelectedReason] = useState<ReportReason | null>(
     null,
@@ -155,9 +166,11 @@ export default function ClubReportScreen() {
 
       <View style={styles.container}>
         <Text style={styles.title}>
-          {isArticleReport
-            ? "게시글을 신고하려는\n이유를 선택해주세요."
-            : "동호회를 신고하려는\n이유를 선택해주세요."}
+          {isCommentReport
+            ? "댓글을 신고하려는\n이유를 선택해주세요."
+            : isArticleReport
+              ? "게시글을 신고하려는\n이유를 선택해주세요."
+              : "동호회를 신고하려는\n이유를 선택해주세요."}
         </Text>
 
         <View style={styles.reasonList}>

--- a/hooks/api/useSocials.ts
+++ b/hooks/api/useSocials.ts
@@ -4,6 +4,7 @@ import {
   blockUser,
   createArticleReport,
   createClubReport,
+  createCommentReport,
   createReport,
   getBlocks,
   getReceivedHearts,
@@ -141,5 +142,16 @@ export function useCreateArticleReportMutation(
   return useMutation({
     mutationFn: (body: IClubReportRequest) =>
       createArticleReport(clubId, articleId, body),
+  });
+}
+
+export function useCreateCommentReportMutation(
+  clubId: number,
+  articleId: number,
+  commentId: number,
+) {
+  return useMutation({
+    mutationFn: (body: IClubReportRequest) =>
+      createCommentReport(clubId, articleId, commentId, body),
   });
 }


### PR DESCRIPTION
## 📝 작업 내용
- 동호회 게시글 댓글 신고를 신규 백엔드 API(`POST /v1/report/clubs/{clubId}/articles/{articleId}/comments/{commentId}`)에 연동했습니다.
- `createCommentReport` API 함수 및 `useCreateCommentReportMutation` 훅 추가
- 신고 화면(`club/report`)에 `commentId` 파라미터 분기 추가 (댓글 신고 모드 타이틀/뮤테이션)
- 게시글 상세 댓글 액션시트의 신고 버튼을 '준비 중' 알럿에서 신고 화면 이동으로 교체

## 🔍 관련 이슈
- #203

## 🧪 테스트 결과
- [x] tsc / eslint 통과
- [ ] staging 실기기 신고 제출 확인

## 💬 기타 참고 사항
- 요청 바디는 기존 게시글 신고와 동일한 `CreateReportRequestDto`(category, reason)를 사용합니다.
- 409(이미 신고한 댓글)는 신고 화면의 기존 '이미 신고한 대상이에요' 처리로 커버됩니다.
- 댓글 차단은 기존 사용자 차단 API를 이미 사용 중이라 추가 작업 없음 (서버에서 차단 사용자 아이템 필터링).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 동호회 게시글의 댓글을 신고할 수 있습니다.
  - 댓글의 신고 메뉴에서 신고 화면으로 이동할 수 있습니다.
  - 댓글, 게시글, 동호회 유형에 따라 신고 안내가 다르게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->