### PR TITLE
fix: 동호회 가입 신청 상태 재진입 시 초기화 문제 수정

### DIFF
--- a/app/club/detail.tsx
+++ b/app/club/detail.tsx
@@ -37,6 +37,7 @@ import {
   useClubDetailQuery,
   useJoinClubMutation,
   useLeaveClubMutation,
+  useMyClubsQuery,
 } from "@/hooks/api/useClub";
 import {
   useAttendMeetingMutation,
@@ -146,6 +147,8 @@ export default function ClubDetailScreen() {
   const [isGuestSheetVisible, setGuestSheetVisible] = useState(false);
 
   const detailQuery = useClubDetailQuery(clubId);
+  // 화면 재진입 시 로컬 joinStatus가 초기화되므로, 내 동호회 목록의 상태(PENDING 등)로 복원한다.
+  const myClubsQuery = useMyClubsQuery(true, { includeInactive: true });
   const cachedThumbnail = useCachedClubThumbnail(clubId);
   const joinMutation = useJoinClubMutation(clubId);
   const leaveMutation = useLeaveClubMutation();
@@ -157,10 +160,15 @@ export default function ClubDetailScreen() {
   );
   const detail = detailQuery.data;
 
+  const myClubStatus =
+    myClubsQuery.data?.items.find((item) => Number(item.clubId) === clubId)
+      ?.status ?? null;
+  // 이 화면에서 방금 바꾼 로컬 상태가 서버 목록 캐시보다 우선한다.
+  const effectiveJoinStatus = joinStatus ?? myClubStatus;
   const isJoined =
-    joinStatus === "ACTIVE" ||
+    effectiveJoinStatus === "ACTIVE" ||
     Boolean(detail?.isJoined && joinStatus !== "LEFT");
-  const isJoinPending = joinStatus === "PENDING";
+  const isJoinPending = effectiveJoinStatus === "PENDING";
   const isHost = detail?.myAuthority === "HOST";
   // 게스트/멤버/호스트 역할과 화면 권한을 한 곳에서 계산한다.
   const viewer = getClubViewer({ isJoined, isHost });


### PR DESCRIPTION
## 📝 작업 내용
- 동호회 가입 신청 후 상세 화면을 나갔다 다시 들어오면 가입 버튼이 다시 활성화되는 문제를 수정했습니다.
- 원인: 신청 상태(`joinStatus`)가 화면 로컬 state로만 관리되고, 상세 API 응답에는 신청 대기 여부 필드가 없어 재진입 시 복원 불가
- 해결: 내 동호회 목록 API(`GET /v1/users/me/clubs`)의 `status`(PENDING 포함)로 상태를 복원하고, 화면에서 방금 바꾼 로컬 상태가 우선하도록 처리

## 🔍 관련 이슈
- 없음 (QA 중 발견 버그 즉시 수정)

## 🧪 테스트 결과
- [x] tsc / eslint 통과
- [ ] 재진입 시 '가입 대기중' 버튼 유지 확인

## 💬 기타 참고 사항
- 가입 신청 뮤테이션이 이미 `club.all` 쿼리를 invalidate하고 있어 신청 직후 목록 캐시는 자동 갱신됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 동호회 상세 화면에 다시 진입해도 가입 상태가 서버 정보에 맞게 복원됩니다.
  * 가입 승인 대기, 가입 완료 상태와 관련된 권한, 탭, 가입 버튼이 일관되게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->