### PR TITLE
[EUM-133] chore: finalize iOS App Store release

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,7 +11,6 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.eum-dating.app",
-      "buildNumber": "14",
       "usesAppleSignIn": true,
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
@@ -21,7 +20,6 @@
     },
     "android": {
       "package": "com.eumdating.app",
-      "versionCode": 1,
       "permissions": [
         "POST_NOTIFICATIONS"
       ],

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-keyboard-controller": "^1.18.5",
+    "react-native-keyboard-controller": "1.18.5",
     "react-native-reanimated": "~4.1.7",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         specifier: ~2.28.0
         version: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-keyboard-controller:
-        specifier: ^1.18.5
+        specifier: 1.18.5
         version: 1.18.5(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-reanimated:
         specifier: ~4.1.7


### PR DESCRIPTION
Related to #210

## 변경 사항
- EAS remote version을 단일 빌드 번호 소스로 정리
- app config의 수동 iOS/Android 빌드 번호 제거
- Expo 권장 keyboard controller 버전 정확히 고정

## 검증
- Expo Doctor 18/18 통과
- lint 오류 0, 기존 경고 3
- frozen lockfile 설치 통과

## 배포 계획
- TestFlight 테스터 배포는 생략
- production build를 App Store Connect에 업로드한 뒤 정식 심사 빌드로 선택