### PR TITLE
[EUM-189] chore: prepare Android Google Play release

### DIFF
--- a/api/axiosInstance.ts
+++ b/api/axiosInstance.ts
@@ -27,6 +27,8 @@ const api = create({
   baseURL: normalizedBaseUrl,
   headers: { "Content-Type": "application/json" },
   withCredentials: true,
+  // 정지된 커넥션이 콜드스타트/화면을 무한 대기시키지 않도록 전역 상한을 둔다.
+  timeout: 15000,
 });
 
 const formatDebugPayload = (payload: unknown) => {
@@ -53,27 +55,43 @@ const formatDebugPayload = (payload: unknown) => {
   }
 };
 
+// 동시 401 다발 시 refresh가 병렬로 여러 번 나가면, refresh token 회전 정책에서
+// 뒤따른 요청들이 전부 실패해 세션이 끊긴다 → 진행 중인 refresh를 공유한다.
+let refreshPromise: Promise<string> | null = null;
+
 export const refreshAccessToken = async () => {
+  if (refreshPromise) {
+    return refreshPromise;
+  }
+
   if (!normalizedBaseUrl) {
     throw new Error(
       "EXPO_PUBLIC_API_BASE_URL is required to refresh access token.",
     );
   }
 
-  const res = await axios.post<ApiSuccessResponse<ITokenRefreshResponse>>(
-    `${normalizedBaseUrl}${REFRESH_TOKEN_PATH}`,
-    {},
-    { withCredentials: true },
-  );
-  const { accessToken: refreshedAccessToken } = res.data.success.data;
+  refreshPromise = (async () => {
+    try {
+      const res = await axios.post<ApiSuccessResponse<ITokenRefreshResponse>>(
+        `${normalizedBaseUrl}${REFRESH_TOKEN_PATH}`,
+        {},
+        { withCredentials: true, timeout: 15000 },
+      );
+      const { accessToken: refreshedAccessToken } = res.data.success.data;
 
-  setAccessToken(refreshedAccessToken);
+      setAccessToken(refreshedAccessToken);
 
-  if (__DEV__) {
-    console.log("[ACCESS_TOKEN][REFRESH]", refreshedAccessToken);
-  }
+      if (__DEV__) {
+        console.log("[ACCESS_TOKEN][REFRESH]", refreshedAccessToken);
+      }
 
-  return refreshedAccessToken;
+      return refreshedAccessToken;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
 };
 
 api.interceptors.request.use((config) => {

--- a/api/axiosInstance.ts
+++ b/api/axiosInstance.ts
@@ -27,8 +27,6 @@ const api = create({
   baseURL: normalizedBaseUrl,
   headers: { "Content-Type": "application/json" },
   withCredentials: true,
-  // 정지된 커넥션이 콜드스타트/화면을 무한 대기시키지 않도록 전역 상한을 둔다.
-  timeout: 15000,
 });
 
 const formatDebugPayload = (payload: unknown) => {

--- a/api/chats/chatSocketApi.ts
+++ b/api/chats/chatSocketApi.ts
@@ -125,7 +125,7 @@ export const createChatSocket = (options: ChatSocketOptions = {}) => {
     console.log("[ChatSocket] create", getChatSocketDebugConfig());
   }
 
-  return io(socketUrl, {
+  const socket = io(socketUrl, {
     path: CHAT_SOCKET_PATH,
     transports: ["websocket"],
     autoConnect: false,
@@ -133,6 +133,15 @@ export const createChatSocket = (options: ChatSocketOptions = {}) => {
     extraHeaders,
     ...options,
   }) as ChatSocket;
+
+  // 소켓을 앱 전역에서 유지하므로, 네트워크 단절 후 자동 재연결이 일어날 때도
+  // (connectChatSocket을 거치지 않고) 최신 accessToken으로 handshake 하도록 갱신한다.
+  socket.io.on("reconnect_attempt", () => {
+    socket.auth = getChatSocketAuth();
+    socket.io.opts.extraHeaders = getChatSocketExtraHeaders();
+  });
+
+  return socket;
 };
 
 export const getChatSocket = (options?: ChatSocketOptions) => {

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,11 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
+    env: {
+      // 릴리즈 번들에서 console.* 제거(오류 추적용 error/warn은 유지)
+      production: {
+        plugins: [["transform-remove-console", { exclude: ["error", "warn"] }]],
+      },
+    },
   };
 };

--- a/docs/android-google-play-release-runbook.html
+++ b/docs/android-google-play-release-runbook.html
@@ -1,0 +1,463 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light" />
+    <title>이음 Android Google Play 정식 배포 Runbook</title>
+    <style>
+      :root {
+        --ink: #1f2533; --muted: #667085; --line: #e7e9ef; --paper: #fff;
+        --canvas: #f7f7fb; --pink: #fc3367; --pink-soft: #fff0f4;
+        --navy: #242944; --green: #14875d; --green-soft: #eaf8f2;
+        --amber: #a86100; --amber-soft: #fff5df; --red: #c33544;
+        --red-soft: #fff0f1; --blue: #275da8; --blue-soft: #edf4ff;
+        --shadow: 0 14px 40px rgba(36, 41, 68, .08);
+      }
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      body {
+        overflow-x: hidden; margin: 0; color: var(--ink); line-height: 1.65; word-break: keep-all;
+        background: radial-gradient(circle at 88% 0%, rgba(252,51,103,.13), transparent 30rem), var(--canvas);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans KR", sans-serif;
+      }
+      a { color: var(--blue); }
+      code { padding: .12rem .34rem; border-radius: .35rem; background: #f1f2f6; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .9em; }
+      pre { overflow-x: auto; margin: .8rem 0 0; padding: 1rem; border-radius: .8rem; color: #eef1ff; background: #202439; font-size: .8rem; line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
+      pre code { padding: 0; color: inherit; background: transparent; }
+      h1, h2, h3, h4 { line-height: 1.25; }
+      .wrap { width: calc(100% - 32px); max-width: 1120px; margin: 0 auto; }
+      .hero { padding: 56px 0 34px; }
+      .hero-card { overflow: hidden; position: relative; padding: 42px; border-radius: 26px; color: white; background: radial-gradient(circle at 105% 125%, rgba(252,51,103,.25) 0 180px, transparent 181px), linear-gradient(135deg,#222741 0%,#343958 68%,#5d2944 100%); box-shadow: var(--shadow); }
+      .eyebrow { display:inline-flex; margin-bottom:1rem; padding:.38rem .72rem; border:1px solid rgba(255,255,255,.2); border-radius:999px; background:rgba(255,255,255,.08); font-size:.78rem; font-weight:800; letter-spacing:.04em; }
+      h1 { max-width: 850px; margin: 0; font-size: clamp(2rem,5vw,3.7rem); letter-spacing:-.04em; overflow-wrap:anywhere; }
+      .hero p { max-width:780px; margin:1rem 0 0; color:#d9dceb; }
+      .hero-meta { display:flex; flex-wrap:wrap; gap:.6rem; margin-top:1.6rem; }
+      .hero-meta span { min-width:0; padding:.45rem .75rem; border-radius:999px; background:rgba(255,255,255,.1); font-size:.82rem; overflow-wrap:anywhere; }
+      .notice { min-width:0; display:grid; grid-template-columns:auto minmax(0,1fr); gap:.8rem; margin:0 0 26px; padding:1rem 1.15rem; border:1px solid #ffd4dc; border-radius:16px; background:var(--pink-soft); }
+      .notice strong { color:#a81f45; }
+      .jump { position:sticky; top:10px; z-index:10; display:flex; flex-wrap:wrap; gap:.45rem; overflow:visible; margin-bottom:28px; padding:.65rem; border:1px solid rgba(231,233,239,.9); border-radius:15px; background:rgba(255,255,255,.92); box-shadow:0 8px 22px rgba(36,41,68,.07); backdrop-filter:blur(12px); }
+      .jump a { flex:0 0 auto; padding:.48rem .72rem; border-radius:10px; color:var(--ink); text-decoration:none; font-size:.82rem; font-weight:800; }
+      .jump a:hover { color:var(--pink); background:var(--pink-soft); }
+      section { margin:28px 0; }
+      .section-head { display:flex; align-items:end; justify-content:space-between; gap:1rem; margin-bottom:14px; }
+      .section-head h2 { margin:0; font-size:clamp(1.45rem,3vw,2rem); letter-spacing:-.025em; }
+      .section-head p { margin:.35rem 0 0; color:var(--muted); }
+      .owner { flex:0 0 auto; padding:.42rem .72rem; border-radius:999px; color:white; background:var(--navy); font-size:.76rem; font-weight:800; }
+      .grid { display:grid; grid-template-columns:repeat(12,1fr); gap:14px; }
+      .card { min-width:0; grid-column:span 6; padding:22px; border:1px solid var(--line); border-radius:18px; background:var(--paper); box-shadow:0 5px 18px rgba(36,41,68,.035); }
+      .card.wide { grid-column:1/-1; }
+      .card.third { grid-column:span 4; }
+      .card h3 { margin:0; font-size:1.08rem; }
+      .card h4 { margin:1.15rem 0 .4rem; font-size:.96rem; }
+      .card p { margin:.55rem 0 0; color:var(--muted); font-size:.92rem; }
+      .card ul, .card ol { margin:.7rem 0 0; padding-left:1.2rem; }
+      .card li + li { margin-top:.35rem; }
+      .tag { display:inline-block; margin-bottom:.65rem; padding:.25rem .55rem; border-radius:999px; font-size:.7rem; font-weight:800; }
+      .tag.blocker { color:var(--red); background:var(--red-soft); }
+      .tag.required { color:var(--amber); background:var(--amber-soft); }
+      .tag.done { color:var(--green); background:var(--green-soft); }
+      .tag.info { color:var(--blue); background:var(--blue-soft); }
+      .status-list { display:grid; gap:.55rem; margin-top:.8rem; }
+      .status-row { display:grid; grid-template-columns:1.25fr 1fr; gap:1rem; align-items:center; padding:.7rem .85rem; border-radius:11px; background:#f8f9fc; font-size:.88rem; }
+      .status { min-width:0; justify-self:end; font-weight:800; text-align:right; overflow-wrap:anywhere; }
+      .status.ok { color:var(--green); } .status.no { color:var(--red); } .status.wait { color:var(--amber); }
+      .checks { display:grid; gap:.5rem; margin-top:.8rem; }
+      .check { position:relative; display:block; min-width:0; padding-left:1.65rem; font-size:.91rem; overflow-wrap:anywhere; }
+      .check input { position:absolute; top:.22rem; left:0; width:1rem; height:1rem; margin:0; accent-color:var(--pink); }
+      .evidence { margin-top:1rem; padding:.85rem 1rem; border-left:4px solid var(--green); border-radius:0 10px 10px 0; background:var(--green-soft); font-size:.86rem; }
+      .warning { border-left-color:var(--amber); background:var(--amber-soft); }
+      table { width:100%; margin-top:.8rem; border-collapse:collapse; font-size:.86rem; }
+      th, td { padding:.7rem; border-bottom:1px solid var(--line); text-align:left; vertical-align:top; }
+      th { color:var(--muted); background:#fafafd; }
+      details { margin-top:.9rem; border:1px solid var(--line); border-radius:12px; background:#fbfbfd; }
+      summary { cursor:pointer; padding:.8rem .9rem; font-weight:800; }
+      details > div { padding:0 .9rem .9rem; }
+      .timeline { display:grid; counter-reset:release; }
+      .step { counter-increment:release; display:grid; grid-template-columns:2.2rem 1fr; gap:.8rem; position:relative; padding-bottom:1.2rem; }
+      .step::before { content:counter(release); z-index:1; display:grid; place-items:center; width:2.2rem; height:2.2rem; border-radius:50%; color:white; background:var(--navy); font-size:.78rem; font-weight:900; }
+      .step:not(:last-child)::after { content:""; position:absolute; top:2rem; left:1.06rem; bottom:0; width:2px; background:var(--line); }
+      .step h4 { margin:.15rem 0 .2rem; } .step p { margin:0; color:var(--muted); font-size:.9rem; }
+      .gate { border-top:5px solid var(--pink); }
+      .sources { display:grid; gap:.55rem; padding:0; list-style:none; }
+      .sources a { display:block; padding:.72rem .85rem; border-radius:10px; background:#f7f8fb; text-decoration:none; }
+      footer { padding:32px 0 50px; color:var(--muted); text-align:center; font-size:.82rem; }
+      @media (max-width:760px) {
+        .wrap { width:calc(100% - 20px); } .hero { padding:18px 0 24px; }
+        .hero-card { padding:26px 20px; border-radius:20px; }
+        h1 { font-size:clamp(1.75rem,8.5vw,2.35rem); }
+        .hero p { font-size:.92rem; line-height:1.6; }
+        .hero-meta { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.45rem; margin-top:1.25rem; }
+        .hero-meta span { display:grid; place-items:center; padding:.5rem .55rem; border-radius:12px; text-align:center; line-height:1.35; }
+        .notice { grid-template-columns:1fr; gap:.35rem; margin-bottom:18px; padding:.9rem; }
+        .notice > span { font-size:1.1rem; }
+        .jump { position:static; display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.4rem; overflow:visible; margin-bottom:20px; padding:.55rem; }
+        .jump a { display:grid; place-items:center; min-width:0; padding:.6rem .35rem; background:#f7f8fb; text-align:center; line-height:1.35; overflow-wrap:anywhere; }
+        .section-head { align-items:start; flex-direction:column; } .card,.card.third { grid-column:1/-1; padding:18px; }
+        .status-row { grid-template-columns:1fr; gap:.15rem; } .status { justify-self:start; text-align:left; }
+        .table-wrap { overflow:visible; }
+        .table-wrap table,.table-wrap tbody,.table-wrap tr,.table-wrap td { display:block; width:100%; min-width:0; }
+        .table-wrap table { margin-top:.8rem; }
+        .table-wrap thead { display:none; }
+        .table-wrap tr { margin-bottom:.65rem; padding:.7rem .8rem; border:1px solid var(--line); border-radius:12px; background:#fafafd; }
+        .table-wrap td { padding:.25rem 0; border:0; overflow-wrap:anywhere; }
+        .table-wrap td::before { display:block; margin-bottom:.08rem; color:var(--muted); font-size:.68rem; font-weight:800; letter-spacing:.02em; }
+        .table-wrap td:nth-child(1)::before { content:"항목"; }
+        .table-wrap td:nth-child(2)::before { content:"사용 · 현황"; }
+        .table-wrap td:nth-child(3)::before { content:"확인 · 조치"; }
+        section { margin:24px 0; } pre { padding:.85rem; font-size:.74rem; }
+        body { word-break:normal; } h2,h3,h4,.notice strong { word-break:keep-all; }
+      }
+      @media (max-width:380px) {
+        .hero-meta { grid-template-columns:1fr; }
+        .eyebrow { font-size:.7rem; }
+      }
+      @media print {
+        body { background:white; } .jump { display:none; } .hero { padding-top:0; }
+        .hero-card,.card { box-shadow:none; } section { break-inside:avoid; }
+        a { color:inherit; text-decoration:none; } input { appearance:none; border:1px solid #777; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="hero">
+      <div class="wrap">
+        <div class="hero-card">
+          <span class="eyebrow">EUM · ANDROID RELEASE 1.1.0</span>
+          <h1>Google Play 정식 배포 Runbook</h1>
+          <p>백엔드·프론트엔드·PM이 이 문서만 보고 작업하고, 모든 Gate 통과 후 Android AAB를 심사·출시하기 위한 실행 문서입니다.</p>
+          <div class="hero-meta">
+            <span>검증일 2026-07-16</span><span>릴리스 이슈 #189</span>
+            <span>현재 상태 NO-GO</span><span>Play 계정 Organization</span><span>예상 최종 AAB 1.1.0 (2)</span>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="wrap">
+      <div class="notice"><span>⚠️</span><div><strong>기존 Android APK는 정식 제출에 사용하지 않습니다.</strong> 현재 EAS에는 2026-07-08의 구버전 preview APK <code>1.0.0 (1)</code>만 있습니다. 아래 차단 항목을 해결하고 최신 릴리스 소스로 production AAB <code>1.1.0 (2)</code>를 새로 생성합니다.</div></div>
+
+      <nav class="jump" aria-label="문서 바로가기">
+        <a href="#status">현재 상태</a><a href="#audit">2회 교차검증</a><a href="#backend">백엔드</a>
+        <a href="#frontend">프론트엔드</a><a href="#pm">PM·Play Console</a><a href="#release">배포 순서</a>
+        <a href="#gates">GO / NO-GO</a><a href="#sources">공식 근거</a>
+      </nav>
+
+      <section id="status">
+        <div class="section-head"><div><h2>현재 상태</h2><p>실제 저장소·EAS·운영 응답을 기준으로 한 판정</p></div><span class="owner">Release Owner</span></div>
+        <div class="grid">
+          <article class="card">
+            <span class="tag done">기술 기반 통과</span><h3>코드와 Android 설정</h3>
+            <div class="status-list">
+              <div class="status-row"><span>패키지 / Firebase</span><span class="status ok">com.eumdating.app 일치</span></div>
+              <div class="status-row"><span>Expo SDK / target SDK</span><span class="status ok">54 / API 36</span></div>
+              <div class="status-row"><span>production API·Socket</span><span class="status ok">운영 주소 번들 삽입 확인</span></div>
+              <div class="status-row"><span>TypeScript / Expo Doctor</span><span class="status ok">통과 / 18·18</span></div>
+              <div class="status-row"><span>Lint</span><span class="status ok">오류 0, 기존 경고 3</span></div>
+              <div class="status-row"><span>production Android export</span><span class="status ok">성공</span></div>
+            </div>
+          </article>
+          <article class="card">
+            <span class="tag blocker">배포 차단</span><h3>아직 해결할 항목</h3>
+            <div class="status-list">
+              <div class="status-row"><span>production 약관</span><span class="status no">0건</span></div>
+              <div class="status-row"><span>Privacy / Support / Delete URL</span><span class="status no">공개 URL 404</span></div>
+              <div class="status-row"><span>탈퇴 API</span><span class="status no">비활성화인지 실제 삭제인지 미확인</span></div>
+              <div class="status-row"><span>최신 production AAB</span><span class="status no">없음</span></div>
+              <div class="status-row"><span>Play Console 조직 검증·앱·정책 상태</span><span class="status wait">접근 권한 없어 미확인</span></div>
+              <div class="status-row"><span>릴리스 소스 추적성</span><span class="status wait">Android 전용 PR 정리 중</span></div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="audit">
+        <div class="section-head"><div><h2>2회 교차검증 결과</h2><p>서로 다른 관점에서 같은 결론이 나오는지 확인했습니다.</p></div><span class="owner">검증 완료</span></div>
+        <div class="grid">
+          <article class="card">
+            <span class="tag info">1회독 · 기술 파이프라인</span><h3>저장소 → EAS → 번들</h3>
+            <ul>
+              <li><code>app.json</code> 패키지명과 <code>google-services.json</code> 일치</li>
+              <li>Expo SDK 54 기본 target SDK 36으로 현재 Play 최소 API 35 충족</li>
+              <li>EAS production 원격 versionCode 1, <code>autoIncrement: true</code> → 다음 2</li>
+              <li>운영 API <code>/api</code> 포함, WebSocket 운영 주소가 Android 번들에 포함</li>
+              <li>Google Play 제출용 AAB 이력은 0건, 과거 preview APK만 2건</li>
+              <li>Expo 최종 매니페스트에서 <code>READ_MEDIA_IMAGES/VIDEO</code> 미선언 및 미사용 특수 권한 제거 확인</li>
+            </ul>
+            <div class="evidence">검증: TypeScript, lint, Expo Doctor 18/18, Android production export, EAS build/version 조회</div>
+          </article>
+          <article class="card">
+            <span class="tag info">2회독 · 정책과 운영</span><h3>Google Play → 실제 서비스</h3>
+            <ul>
+              <li>Dating 앱: Play Console에서 18+만 선택하고 <strong>Restrict minor access</strong> 활성화 필수</li>
+              <li>Social/Dating 앱: 공개 CSAE 금지 기준, 신고 채널, CSAM 대응, 아동 안전 담당자 필수</li>
+              <li>UGC: 약관 동의, 금지행위 명시, 신고·차단뿐 아니라 실제 검토·조치 운영 필요</li>
+              <li>계정 생성 앱: 앱 내 탈퇴와 앱 밖에서 요청 가능한 공개 삭제 URL 모두 필요</li>
+              <li>Data safety, 개인정보처리방침, 앱 접근용 심사 계정, 콘텐츠 등급 필수</li>
+              <li>팀 계정은 Organization이므로 개인 계정 대상 12명·14일 closed test 의무는 적용되지 않음</li>
+              <li>대신 D-U-N-S·조직 문서·담당자 신원·이메일·전화·웹사이트 검증 상태 확인 필수</li>
+            </ul>
+            <div class="evidence warning">교차결론: 코드 컴파일은 가능하지만 운영·정책·AAB가 미완료이므로 현재 정식 제출은 NO-GO</div>
+          </article>
+        </div>
+      </section>
+
+      <section id="backend">
+        <div class="section-head"><div><h2>백엔드 작업</h2><p>각 항목의 완료 증빙까지 Release Owner에게 전달합니다.</p></div><span class="owner">Backend</span></div>
+        <div class="grid">
+          <article class="card">
+            <span class="tag blocker">P0 · 회원가입 차단</span><h3>운영 약관 1~3번 이관</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />production DB에 서비스이용약관·개인정보처리방침·마케팅 동의 등록</label>
+              <label class="check"><input type="checkbox" />staging의 4~10번 <code>Seed marketing agreement</code>는 제외</label>
+              <label class="check"><input type="checkbox" />본문·활성 상태·적용 일시를 production 기준으로 확인</label>
+            </div>
+            <pre><code>curl https://api.eum-dating.com/api/v1/agreements
+# 완료 기준: items에 agreementId 1, 2, 3과 실제 body가 반환됨</code></pre>
+          </article>
+          <article class="card">
+            <span class="tag blocker">P0 · 계정삭제</span><h3>탈퇴의 실제 삭제 보장</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /><code>PATCH /v1/users/me/deactivate</code>가 로그인만 막는 비활성화인지 확인</label>
+              <label class="check"><input type="checkbox" />계정 및 연관 개인정보·사진·음성·토큰을 삭제 또는 익명화</label>
+              <label class="check"><input type="checkbox" />법적 보존 데이터가 있으면 종류·기간·사유를 개인정보처리방침에 명시</label>
+              <label class="check"><input type="checkbox" />삭제 후 기존 토큰·소셜 로그인으로 사용자 데이터 접근 불가 확인</label>
+            </div>
+            <div class="evidence">증빙: 전용 테스트 계정 탈퇴 전후 DB/스토리지 결과와 재로그인 결과</div>
+          </article>
+          <article class="card">
+            <span class="tag blocker">P0 · 기술 집행</span><h3>신고·차단·제재 기능 보장</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />사용자·채팅·동호회·게시글·댓글 신고가 운영 큐에 정상 적재</label>
+              <label class="check"><input type="checkbox" />차단 즉시 프로필·대화·UGC 노출과 상호작용 제한</label>
+              <label class="check"><input type="checkbox" />운영자가 콘텐츠 삭제·계정 정지·영구 차단을 집행할 API 또는 관리 도구 제공</label>
+              <label class="check"><input type="checkbox" />PM이 정한 CSAM 절차에 따라 즉시 접근 차단·증거 보존을 수행할 수 있게 구현</label>
+            </div>
+            <div class="evidence">책임 경계: 기준·SLA·법적 절차·담당자 지정은 PM, 신고 적재와 실제 제재 집행은 Backend</div>
+          </article>
+          <article class="card">
+            <span class="tag required">P1 · 심사 지원</span><h3>운영 심사 계정</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />전용 Kakao 리뷰 계정 생성 및 production 로그인 성공</label>
+              <label class="check"><input type="checkbox" />OTP·기기승인 없이 검토 가능하거나 우회 절차 제공</label>
+              <label class="check"><input type="checkbox" />온보딩 완료 계정과 신규가입 검증 계정을 구분해 제공</label>
+              <label class="check"><input type="checkbox" />신고·차단·탈퇴를 검토할 테스트 데이터 준비</label>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="frontend">
+        <div class="section-head"><div><h2>프론트엔드 작업</h2><p>최종 소스를 고정한 후 AAB를 한 번만 생성합니다.</p></div><span class="owner">Frontend</span></div>
+        <div class="grid">
+          <article class="card">
+            <span class="tag blocker">P0 · 소스 고정</span><h3>릴리스 기준 만들기</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />이슈 <a href="https://github.com/UMC-Eum/Frontend/issues/189">#189</a>에 Android 체크리스트와 담당자 연결</label>
+              <label class="check"><input type="checkbox" />릴리스 안정화 커밋과 전역 timeout 수정사항을 커밋·push·PR 병합</label>
+              <label class="check"><input type="checkbox" />최신 <code>dev</code>에서 Android 릴리스 브랜치 생성</label>
+              <label class="check"><input type="checkbox" /><code>git status</code> clean 및 HEAD SHA를 이슈에 기록</label>
+            </div>
+            <p>현재 브랜치는 원격보다 2커밋 앞서고 <code>api/axiosInstance.ts</code>가 미커밋 상태이므로 지금 빌드하면 재현 가능한 정식 산출물이 아닙니다.</p>
+          </article>
+          <article class="card">
+            <span class="tag done">현재 통과</span><h3>Android 네이티브 설정</h3>
+            <div class="status-list">
+              <div class="status-row"><span>applicationId</span><span class="status ok">com.eumdating.app</span></div>
+              <div class="status-row"><span>target / compile SDK</span><span class="status ok">36 / 36</span></div>
+              <div class="status-row"><span>Adaptive icon</span><span class="status ok">foreground·background·monochrome 존재</span></div>
+              <div class="status-row"><span>FCM 설정</span><span class="status ok">패키지명 일치</span></div>
+              <div class="status-row"><span>정식 산출물 형식</span><span class="status ok">production 기본 AAB</span></div>
+              <div class="status-row"><span>원격 versionCode</span><span class="status ok">1 → 다음 2</span></div>
+            </div>
+          </article>
+          <article class="card wide">
+            <span class="tag required">권한 점검</span><h3>실제 매니페스트와 Play Console 설명 일치</h3>
+            <div class="table-wrap"><table>
+              <thead><tr><th>권한</th><th>사용 이유</th><th>조치</th></tr></thead>
+              <tbody>
+                <tr><td>RECORD_AUDIO</td><td>음성 프로필·이상형·채팅 음성 녹음</td><td>Data safety·개인정보처리방침에 음성 수집/보관/삭제 명시</td></tr>
+                <tr><td>CAMERA</td><td>프로필·게시글·채팅 사진 촬영</td><td>필수 유지. 기능 사용 시점 요청 및 거부 흐름 실기기 검증</td></tr>
+                <tr><td>POST_NOTIFICATIONS</td><td>채팅·매칭·활동 알림</td><td>Android 13+ 런타임 요청과 거부 흐름 검증</td></tr>
+                <tr><td>READ/WRITE_EXTERNAL_STORAGE</td><td>Expo ImagePicker의 Android 12 이하 갤러리·Android 9 이하 카메라 호환</td><td>호환성 회귀를 막기 위해 유지. 정책 대상인 <code>READ_MEDIA_IMAGES/VIDEO</code>는 선언하지 않음</td></tr>
+                <tr><td>SYSTEM_ALERT_WINDOW / FGS media playback</td><td>사용하지 않음</td><td>config plugin의 <code>tools:node=&quot;remove&quot;</code>로 최종 병합 매니페스트에서 제거</td></tr>
+              </tbody>
+            </table></div>
+            <div class="evidence">판정: 추가 권한 삭제는 부적절합니다. 앱은 Android Photo Picker를 사용하고 광범위 사진·동영상 권한을 갖지 않으므로 별도 Photos and Videos access 선언 대상이 아닙니다.</div>
+          </article>
+          <article class="card">
+            <span class="tag blocker">P0 · 공개 경로</span><h3>앱 내 정책·지원 연결</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />production 약관 API 반영 후 마이페이지 약관·개인정보 본문 표시</label>
+              <label class="check"><input type="checkbox" /><code>SUPPORT_URL</code> 확정 후 고객지원 행 노출</label>
+              <label class="check"><input type="checkbox" />공개 개인정보처리방침과 계정삭제 페이지를 앱에서도 접근 가능하게 연결</label>
+              <label class="check"><input type="checkbox" />탈퇴 직전 삭제 범위·보존 항목·복구 불가 안내 표시</label>
+            </div>
+          </article>
+          <article class="card">
+            <span class="tag required">P0 · AAB 전 실기기</span><h3>Android 스모크 테스트</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />신규 설치 → Kakao 로그인 → 약관 → 온보딩 완료</label>
+              <label class="check"><input type="checkbox" />카메라·사진·마이크·알림 각각 허용/거부</label>
+              <label class="check"><input type="checkbox" />프로필 사진·음성 업로드, 추천·채팅·WebSocket 재연결</label>
+              <label class="check"><input type="checkbox" />FCM foreground/background/종료 상태 수신 및 딥링크</label>
+              <label class="check"><input type="checkbox" />사용자·채팅·게시글·댓글 신고와 차단</label>
+              <label class="check"><input type="checkbox" />탈퇴 후 토큰 제거·재접속 불가</label>
+            </div>
+          </article>
+          <article class="card wide">
+            <span class="tag info">최종 빌드 명령</span><h3>모든 Build Gate 통과 후 실행</h3>
+            <pre><code>git pull --ff-only origin dev
+git status                         # 반드시 clean
+pnpm install --frozen-lockfile
+pnpm exec tsc --noEmit
+pnpm lint
+npx expo-doctor
+npx eas-cli build:version:get --platform android --profile production
+npx eas-cli build --platform android --profile production
+
+# 예상 결과: Android App Bundle 1.1.0 (2), distribution=store</code></pre>
+            <p>자동 제출 설정은 아직 없습니다. 첫 출시는 Play Console에 AAB를 수동 업로드하는 것이 가장 단순합니다. 반복 배포가 시작된 뒤에만 서비스 계정과 <code>eas submit</code> 자동화를 추가합니다.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="pm">
+        <div class="section-head"><div><h2>PM·Play Console 작업</h2><p>콘솔에서 직접 완료하고 화면 캡처 또는 상태 링크를 증빙으로 남깁니다.</p></div><span class="owner">PM / Play Admin</span></div>
+        <div class="grid">
+          <article class="card">
+            <span class="tag blocker">P0 · 공개 웹</span><h3>정책과 계정삭제 URL</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /><code>/privacy</code>: 개인정보 유형·목적·제3자·보관·삭제·문의처</label>
+              <label class="check"><input type="checkbox" /><code>/terms</code>: UGC 금지행위와 제재, CSAE 명시적 금지 포함</label>
+              <label class="check"><input type="checkbox" /><code>/support</code>: 실제 수신 가능한 문의 채널</label>
+              <label class="check"><input type="checkbox" /><code>/delete-account</code>: 앱 없이 삭제 요청 가능한 폼 또는 이메일</label>
+              <label class="check"><input type="checkbox" />로그인·지역제한 없이 모바일/PC에서 HTTP 200</label>
+            </div>
+            <p>현재 위 네 주소는 모두 404입니다. 개인정보처리방침은 PDF가 아닌 공개·비편집 웹페이지여야 합니다.</p>
+          </article>
+          <article class="card">
+            <span class="tag blocker">P0 · Dating 전용</span><h3>미성년자 차단과 아동 안전</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />Target audience를 <strong>18 and over만</strong> 선택</label>
+              <label class="check"><input type="checkbox" /><strong>Restrict minor access</strong> 체크</label>
+              <label class="check"><input type="checkbox" />공개 정책에 EUM/이음 명칭과 CSAE 금지 기준 명시</label>
+              <label class="check"><input type="checkbox" />Child safety standards 선언과 담당 연락처 제출</label>
+              <label class="check"><input type="checkbox" />콘텐츠 등급에 Dating·UGC·채팅·사용자 사진/음성을 정확히 응답</label>
+            </div>
+          </article>
+          <article class="card">
+            <span class="tag blocker">P0 · 운영 정책</span><h3>신고·제재·CSAM 책임 확정</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />신고 검토 담당자와 평시·긴급 처리 SLA 확정</label>
+              <label class="check"><input type="checkbox" />콘텐츠 삭제·계정 정지·영구 차단 기준과 이의제기 절차 확정</label>
+              <label class="check"><input type="checkbox" />CSAM 발견 시 접근 차단·증거 보존·법적 신고·Google 통지 절차를 법률 검토 후 문서화</label>
+              <label class="check"><input type="checkbox" />아동 안전 담당자와 실제 수신·회신 가능한 전용 이메일 지정</label>
+              <label class="check"><input type="checkbox" />정책을 Backend 집행 요건과 고객지원 응대 문안으로 전달</label>
+            </div>
+            <div class="evidence">PM 책임이 맞습니다. 단, 법적 신고·보존 기준은 PM 단독 판단이 아니라 회사 책임자 또는 법률 자문 확인이 필요합니다.</div>
+          </article>
+          <article class="card wide">
+            <span class="tag blocker">P0 · Data safety</span><h3>실제 앱·백엔드·SDK 기준으로 작성</h3>
+            <div class="table-wrap"><table>
+              <thead><tr><th>검토할 데이터</th><th>앱의 사용 예</th><th>PM 확인 질문</th></tr></thead>
+              <tbody>
+                <tr><td>개인정보</td><td>소셜 계정, 이름, 생년/나이, 성별, 지역, 소개</td><td>수집/필수 여부, 사용 목적, 공유 대상, 보관 기간</td></tr>
+                <tr><td>사진·음성</td><td>프로필, 게시글, 채팅, 음성 분석</td><td>원본·파생 데이터 각각의 보관 및 삭제 시점</td></tr>
+                <tr><td>메시지·UGC</td><td>채팅, 동호회, 게시글, 댓글, 신고</td><td>운영 검토 접근, 보관, 사용자 삭제 범위</td></tr>
+                <tr><td>기기·앱 활동</td><td>FCM 토큰, Android ID, 앱 버전, 알림</td><td>분석/진단 SDK 여부와 Firebase 처리 범위</td></tr>
+                <tr><td>보안</td><td>HTTPS/WSS 전송, 로그인 토큰</td><td>전송 암호화, 사용자 삭제 요청, 데이터 공유 여부</td></tr>
+              </tbody>
+            </table></div>
+            <p>프론트 코드만 보고 임의 작성하지 않습니다. 백엔드의 저장·제3자 처리·보존 정책과 맞춰야 하며 불일치는 심사 거절 사유가 됩니다.</p>
+          </article>
+          <article class="card">
+            <span class="tag required">스토어 등록정보</span><h3>사용자에게 보이는 페이지</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />앱 이름, 짧은 설명, 전체 설명, 카테고리 Dating</label>
+              <label class="check"><input type="checkbox" />512×512 아이콘, 1024×500 feature graphic</label>
+              <label class="check"><input type="checkbox" />실제 Android 휴대전화 스크린샷 최소 2장 이상</label>
+              <label class="check"><input type="checkbox" />지원 이메일, 웹사이트, 개인정보처리방침 URL</label>
+              <label class="check"><input type="checkbox" />광고 포함 여부, 가격(무료/유료), 배포 국가 확정</label>
+            </div>
+            <p>저장소에는 앱 아이콘은 있으나 feature graphic과 Play Store 스크린샷은 확인되지 않았습니다.</p>
+          </article>
+          <article class="card">
+            <span class="tag blocker">심사 접근</span><h3>App access와 Organization 계정</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" />App access에 Kakao 리뷰 계정·비밀번호·로그인 절차 입력</label>
+              <label class="check"><input type="checkbox" />리뷰어가 핵심 기능과 신고·차단·탈퇴까지 접근 가능</label>
+              <label class="check"><input type="checkbox" />Play Console 계정 유형이 Organization인지 확인</label>
+              <label class="check"><input type="checkbox" />Google Payments의 법인명·주소·D-U-N-S 정보가 사업자 서류와 일치</label>
+              <label class="check"><input type="checkbox" />조직 문서와 권한 있는 담당자 신원 검증 완료</label>
+              <label class="check"><input type="checkbox" />개발자·연락용 이메일과 전화번호, 조직 웹사이트 검증 완료</label>
+            </div>
+            <p>Organization 계정에는 새 개인 계정 전용 12명·14일 closed test 의무가 없습니다. 내부/closed test는 품질 확인용 선택 절차로만 사용합니다.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="release">
+        <div class="section-head"><div><h2>실제 배포 순서</h2><p>위에서 아래로 한 번만 진행합니다.</p></div><span class="owner">Release Owner</span></div>
+        <article class="card wide">
+          <div class="timeline">
+            <div class="step"><div><h4>백엔드와 공개 웹 차단 해소</h4><p>운영 약관 1~3, 실제 계정삭제, UGC/CSAE 운영, privacy·terms·support·delete-account URL을 완료합니다.</p></div></div>
+            <div class="step"><div><h4>Play Console 앱과 정책 설정</h4><p>패키지 <code>com.eumdating.app</code>로 앱을 만들고 App content, 18+, Restrict minor access, Data safety, App access를 완료합니다. 패키지명은 생성 후 변경할 수 없습니다.</p></div></div>
+            <div class="step"><div><h4>최종 소스 병합·고정</h4><p>이슈 #189 기준 PR을 병합하고 clean release branch의 HEAD SHA를 기록합니다.</p></div></div>
+            <div class="step"><div><h4>production AAB 생성</h4><p><code>eas build --platform android --profile production</code>으로 예상 <code>1.1.0 (2)</code>를 생성합니다.</p></div></div>
+            <div class="step"><div><h4>내부 또는 closed track 업로드</h4><p>Play App Signing을 활성화하고 AAB를 업로드합니다. Organization 계정이므로 12명·14일 의무 없이 내부 검증 후 production으로 진행할 수 있습니다.</p></div></div>
+            <div class="step"><div><h4>Google 자동 검사와 실기기 확인</h4><p>Pre-launch report, 권한·Data safety 경고, Android vitals, 기기 호환성을 확인하고 AAB 설치본으로 스모크 테스트합니다.</p></div></div>
+            <div class="step"><div><h4>Production release 생성</h4><p>릴리스 노트 작성, 국가·가격·출시 방식과 Managed publishing 여부를 확정하고 Review release에서 오류가 0인지 확인합니다.</p></div></div>
+            <div class="step"><div><h4>심사 제출 → 승인 → 출시</h4><p>Send for review 후 정책 메일과 Console 상태를 추적합니다. 승인 뒤 Publish 또는 예약된 Managed publishing으로 공개합니다.</p></div></div>
+            <div class="step"><div><h4>출시 직후 모니터링</h4><p>Play 설치본의 로그인·API·FCM·채팅을 재확인하고 Android vitals의 crash/ANR 및 운영 신고 큐를 모니터링합니다.</p></div></div>
+          </div>
+        </article>
+      </section>
+
+      <section id="gates">
+        <div class="section-head"><div><h2>최종 GO / NO-GO</h2><p>한 항목이라도 미완료면 다음 단계로 넘어가지 않습니다.</p></div><span class="owner">All Owners</span></div>
+        <div class="grid">
+          <article class="card third gate"><span class="tag blocker">Gate A · AAB 생성 전</span><h3>서비스 준비</h3><div class="checks">
+            <label class="check"><input type="checkbox" />운영 약관 1~3 정상</label><label class="check"><input type="checkbox" />삭제·UGC·CSAE 운영 확정</label>
+            <label class="check"><input type="checkbox" />공개 URL 모두 200</label><label class="check"><input type="checkbox" />clean release SHA</label>
+          </div></article>
+          <article class="card third gate"><span class="tag blocker">Gate B · Play 업로드 전</span><h3>산출물 준비</h3><div class="checks">
+            <label class="check"><input type="checkbox" />AAB 1.1.0 (2) FINISHED</label><label class="check"><input type="checkbox" />production 환경 포함</label>
+            <label class="check"><input type="checkbox" />Android 실기기 스모크 통과</label><label class="check"><input type="checkbox" />Play App Signing 준비</label>
+          </div></article>
+          <article class="card third gate"><span class="tag blocker">Gate C · 심사 제출 전</span><h3>콘솔 준비</h3><div class="checks">
+            <label class="check"><input type="checkbox" />스토어 등록정보 완료</label><label class="check"><input type="checkbox" />Data safety·삭제 URL 완료</label>
+            <label class="check"><input type="checkbox" />18+·minor restriction·등급 완료</label><label class="check"><input type="checkbox" />App access와 조직 계정 검증 완료</label>
+          </div></article>
+          <article class="card wide">
+            <span class="tag blocker">현재 판정</span><h3>NO-GO — production AAB를 아직 만들지 마세요.</h3>
+            <p>기술 검증은 통과했지만 Gate A의 운영 약관, 공개 정책/삭제 URL, 탈퇴 실제 삭제, UGC·아동 안전 운영, clean release SHA가 미완료입니다. 이 항목이 완료되면 최신 production AAB <code>1.1.0 (2)</code>를 만들고 Gate B·C를 진행할 수 있습니다.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="sources">
+        <div class="section-head"><div><h2>공식 근거</h2><p>정책 판단은 아래 Google Play·Expo 공식 문서를 기준으로 했습니다.</p></div></div>
+        <article class="card wide"><ul class="sources">
+          <li><a href="https://docs.expo.dev/versions/v54.0.0/">Expo SDK 54 — Android compile/target SDK 36</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/11926878">Google Play target API level requirements</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/9844279">Android App Bundle publishing requirement</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/10144311">User Data and privacy policy</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/10787469">Data safety section</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/13327111">Account deletion requirements</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/9876937">User Generated Content policy</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/14747720">Child Safety Standards for Social and Dating apps</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/16935362">Restricted permissions — Photo and Video permissions</a></li>
+          <li><a href="https://docs.expo.dev/versions/latest/sdk/imagepicker/">Expo ImagePicker — Android system picker와 자동 권한</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/16302250">Age-Restricted Content and Functionality</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/9867159">Target audience and Restrict minor access</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/10840893">Organization developer account and contact requirements</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/10841920">Developer identity verification</a></li>
+          <li><a href="https://support.google.com/googleplay/android-developer/answer/9859655">Content rating requirements</a></li>
+        </ul></article>
+      </section>
+    </main>
+
+    <footer><div class="wrap">EUM Android Google Play Release Runbook · 기준일 2026-07-16 · 파일을 그대로 전달하면 PC와 모바일 브라우저에서 열 수 있습니다.</div></footer>
+  </body>
+</html>

--- a/docs/android-google-play-release-runbook.html
+++ b/docs/android-google-play-release-runbook.html
@@ -165,7 +165,7 @@
               <div class="status-row"><span>탈퇴 API</span><span class="status no">비활성화인지 실제 삭제인지 미확인</span></div>
               <div class="status-row"><span>최신 production AAB</span><span class="status no">없음</span></div>
               <div class="status-row"><span>Play Console 조직 검증·앱·정책 상태</span><span class="status wait">접근 권한 없어 미확인</span></div>
-              <div class="status-row"><span>릴리스 소스 추적성</span><span class="status wait">Android 전용 PR 정리 중</span></div>
+              <div class="status-row"><span>릴리스 소스 추적성</span><span class="status ok">PR #212로 dev 병합 완료</span></div>
             </div>
           </article>
         </div>
@@ -182,7 +182,7 @@
               <li>EAS production 원격 versionCode 1, <code>autoIncrement: true</code> → 다음 2</li>
               <li>운영 API <code>/api</code> 포함, WebSocket 운영 주소가 Android 번들에 포함</li>
               <li>Google Play 제출용 AAB 이력은 0건, 과거 preview APK만 2건</li>
-              <li>Expo 최종 매니페스트에서 <code>READ_MEDIA_IMAGES/VIDEO</code> 미선언 및 미사용 특수 권한 제거 확인</li>
+              <li>Expo prebuild 매니페스트에서 <code>READ_MEDIA_IMAGES/VIDEO</code> 미선언 및 미사용 특수 권한 제거 지시 확인</li>
             </ul>
             <div class="evidence">검증: TypeScript, lint, Expo Doctor 18/18, Android production export, EAS build/version 조회</div>
           </article>
@@ -251,14 +251,14 @@
         <div class="section-head"><div><h2>프론트엔드 작업</h2><p>최종 소스를 고정한 후 AAB를 한 번만 생성합니다.</p></div><span class="owner">Frontend</span></div>
         <div class="grid">
           <article class="card">
-            <span class="tag blocker">P0 · 소스 고정</span><h3>릴리스 기준 만들기</h3>
+            <span class="tag done">완료 · 소스 고정</span><h3>릴리스 기준 만들기</h3>
             <div class="checks">
-              <label class="check"><input type="checkbox" />이슈 <a href="https://github.com/UMC-Eum/Frontend/issues/189">#189</a>에 Android 체크리스트와 담당자 연결</label>
-              <label class="check"><input type="checkbox" />릴리스 안정화 커밋과 전역 timeout 수정사항을 커밋·push·PR 병합</label>
-              <label class="check"><input type="checkbox" />최신 <code>dev</code>에서 Android 릴리스 브랜치 생성</label>
-              <label class="check"><input type="checkbox" /><code>git status</code> clean 및 HEAD SHA를 이슈에 기록</label>
+              <label class="check"><input type="checkbox" checked disabled />이슈 <a href="https://github.com/UMC-Eum/Frontend/issues/189">#189</a>에 Android 릴리스 작업 연결</label>
+              <label class="check"><input type="checkbox" checked disabled />릴리스 안정화와 전역 timeout 수정사항을 커밋·push·PR <a href="https://github.com/UMC-Eum/Frontend/pull/212">#212</a> 병합</label>
+              <label class="check"><input type="checkbox" checked disabled />최신 <code>origin/dev</code>에서 <code>chore/EUM-189-android-playstore-release</code> 생성</label>
+              <label class="check"><input type="checkbox" checked disabled />TypeScript·lint·Expo Doctor·production Android export 통과</label>
             </div>
-            <p>현재 브랜치는 원격보다 2커밋 앞서고 <code>api/axiosInstance.ts</code>가 미커밋 상태이므로 지금 빌드하면 재현 가능한 정식 산출물이 아닙니다.</p>
+            <p>릴리스 소스 정리는 완료됐습니다. 이후 기능 수정이 생기면 반드시 새 PR을 <code>dev</code>에 병합한 뒤 그 최신 SHA로 AAB를 생성합니다.</p>
           </article>
           <article class="card">
             <span class="tag done">현재 통과</span><h3>Android 네이티브 설정</h3>
@@ -283,7 +283,7 @@
                 <tr><td>SYSTEM_ALERT_WINDOW / FGS media playback</td><td>사용하지 않음</td><td>config plugin의 <code>tools:node=&quot;remove&quot;</code>로 최종 병합 매니페스트에서 제거</td></tr>
               </tbody>
             </table></div>
-            <div class="evidence">판정: 추가 권한 삭제는 부적절합니다. 앱은 Android Photo Picker를 사용하고 광범위 사진·동영상 권한을 갖지 않으므로 별도 Photos and Videos access 선언 대상이 아닙니다.</div>
+            <div class="evidence">판정: 추가 권한 삭제는 부적절합니다. 앱은 Android Photo Picker를 사용하고 광범위 사진·동영상 권한을 갖지 않으므로 별도 Photos and Videos access 선언 대상이 아닙니다. AAB 업로드 후 App bundle explorer의 최종 병합 권한을 한 번 더 확인합니다.</div>
           </article>
           <article class="card">
             <span class="tag blocker">P0 · 공개 경로</span><h3>앱 내 정책·지원 연결</h3>
@@ -419,7 +419,7 @@ npx eas-cli build --platform android --profile production
         <div class="grid">
           <article class="card third gate"><span class="tag blocker">Gate A · AAB 생성 전</span><h3>서비스 준비</h3><div class="checks">
             <label class="check"><input type="checkbox" />운영 약관 1~3 정상</label><label class="check"><input type="checkbox" />삭제·UGC·CSAE 운영 확정</label>
-            <label class="check"><input type="checkbox" />공개 URL 모두 200</label><label class="check"><input type="checkbox" />clean release SHA</label>
+            <label class="check"><input type="checkbox" />공개 URL 모두 200</label><label class="check"><input type="checkbox" checked disabled />clean release SHA</label>
           </div></article>
           <article class="card third gate"><span class="tag blocker">Gate B · Play 업로드 전</span><h3>산출물 준비</h3><div class="checks">
             <label class="check"><input type="checkbox" />AAB 1.1.0 (2) FINISHED</label><label class="check"><input type="checkbox" />production 환경 포함</label>
@@ -431,7 +431,7 @@ npx eas-cli build --platform android --profile production
           </div></article>
           <article class="card wide">
             <span class="tag blocker">현재 판정</span><h3>NO-GO — production AAB를 아직 만들지 마세요.</h3>
-            <p>기술 검증은 통과했지만 Gate A의 운영 약관, 공개 정책/삭제 URL, 탈퇴 실제 삭제, UGC·아동 안전 운영, clean release SHA가 미완료입니다. 이 항목이 완료되면 최신 production AAB <code>1.1.0 (2)</code>를 만들고 Gate B·C를 진행할 수 있습니다.</p>
+            <p>릴리스 소스와 권한 검증은 완료됐지만 Gate A의 운영 약관, 공개 정책/삭제 URL, 탈퇴 실제 삭제, UGC·아동 안전 운영이 미완료입니다. 이 항목이 완료되면 최신 production AAB <code>1.1.0 (2)</code>를 만들고 Gate B·C를 진행할 수 있습니다.</p>
           </article>
         </div>
       </section>

--- a/docs/ios-app-store-release-runbook.html
+++ b/docs/ios-app-store-release-runbook.html
@@ -1,0 +1,753 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light" />
+    <title>이음 iOS App Store 정식 배포 Runbook</title>
+    <style>
+      :root {
+        --ink: #1f2533;
+        --muted: #667085;
+        --line: #e7e9ef;
+        --paper: #ffffff;
+        --canvas: #f7f7fb;
+        --pink: #fc3367;
+        --pink-soft: #fff0f4;
+        --navy: #242944;
+        --green: #14875d;
+        --green-soft: #eaf8f2;
+        --amber: #a86100;
+        --amber-soft: #fff5df;
+        --red: #c33544;
+        --red-soft: #fff0f1;
+        --blue: #275da8;
+        --blue-soft: #edf4ff;
+        --shadow: 0 14px 40px rgba(36, 41, 68, 0.08);
+      }
+
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      body {
+        margin: 0;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at 88% 0%, rgba(252, 51, 103, 0.13), transparent 30rem),
+          var(--canvas);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans KR", sans-serif;
+        line-height: 1.65;
+        word-break: keep-all;
+      }
+
+      a { color: var(--blue); }
+      code {
+        padding: 0.12rem 0.34rem;
+        border-radius: 0.35rem;
+        background: #f1f2f6;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.9em;
+      }
+      pre {
+        overflow-x: auto;
+        margin: 0.8rem 0 0;
+        padding: 1rem;
+        border-radius: 0.8rem;
+        color: #eef1ff;
+        background: #202439;
+        font-size: 0.82rem;
+        line-height: 1.55;
+      }
+      pre code { padding: 0; color: inherit; background: transparent; }
+
+      .wrap { width: min(1120px, calc(100% - 32px)); margin: 0 auto; }
+      .hero { padding: 56px 0 34px; }
+      .hero-card {
+        overflow: hidden;
+        position: relative;
+        padding: 42px;
+        border-radius: 26px;
+        color: white;
+        background: linear-gradient(135deg, #222741 0%, #343958 68%, #5d2944 100%);
+        box-shadow: var(--shadow);
+      }
+      .hero-card::after {
+        content: "";
+        position: absolute;
+        right: -80px;
+        bottom: -120px;
+        width: 320px;
+        height: 320px;
+        border-radius: 50%;
+        background: rgba(252, 51, 103, 0.25);
+        filter: blur(2px);
+      }
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        margin-bottom: 1rem;
+        padding: 0.38rem 0.72rem;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.08);
+        font-size: 0.78rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+      }
+      h1, h2, h3, h4 { line-height: 1.25; }
+      h1 { max-width: 760px; margin: 0; font-size: clamp(2rem, 5vw, 3.7rem); letter-spacing: -0.04em; }
+      .hero p { max-width: 720px; margin: 1rem 0 0; color: #d9dceb; }
+      .hero-meta { display: flex; flex-wrap: wrap; gap: 0.6rem; margin-top: 1.6rem; }
+      .hero-meta span { padding: 0.45rem 0.75rem; border-radius: 999px; background: rgba(255,255,255,0.1); font-size: 0.82rem; }
+
+      .notice {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.8rem;
+        margin: 0 0 26px;
+        padding: 1rem 1.15rem;
+        border: 1px solid #ffd4dc;
+        border-radius: 16px;
+        background: var(--pink-soft);
+      }
+      .notice strong { color: #a81f45; }
+
+      .jump {
+        position: sticky;
+        top: 10px;
+        z-index: 10;
+        display: flex;
+        gap: 0.45rem;
+        overflow-x: auto;
+        margin-bottom: 28px;
+        padding: 0.65rem;
+        border: 1px solid rgba(231,233,239,0.9);
+        border-radius: 15px;
+        background: rgba(255,255,255,0.9);
+        box-shadow: 0 8px 22px rgba(36,41,68,0.07);
+        backdrop-filter: blur(12px);
+      }
+      .jump a {
+        flex: 0 0 auto;
+        padding: 0.48rem 0.72rem;
+        border-radius: 10px;
+        color: var(--ink);
+        text-decoration: none;
+        font-size: 0.82rem;
+        font-weight: 700;
+      }
+      .jump a:hover { color: var(--pink); background: var(--pink-soft); }
+
+      section { margin: 28px 0; }
+      .section-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; margin-bottom: 14px; }
+      .section-head h2 { margin: 0; font-size: clamp(1.45rem, 3vw, 2rem); letter-spacing: -0.025em; }
+      .section-head p { margin: 0.35rem 0 0; color: var(--muted); }
+      .owner {
+        flex: 0 0 auto;
+        padding: 0.42rem 0.72rem;
+        border-radius: 999px;
+        color: white;
+        background: var(--navy);
+        font-size: 0.76rem;
+        font-weight: 800;
+      }
+
+      .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 14px; }
+      .card {
+        grid-column: span 6;
+        padding: 22px;
+        border: 1px solid var(--line);
+        border-radius: 18px;
+        background: var(--paper);
+        box-shadow: 0 5px 18px rgba(36, 41, 68, 0.035);
+      }
+      .card.wide { grid-column: 1 / -1; }
+      .card.third { grid-column: span 4; }
+      .card h3 { margin: 0; font-size: 1.08rem; }
+      .card h4 { margin: 1.2rem 0 0.45rem; font-size: 0.96rem; }
+      .card p { margin: 0.55rem 0 0; color: var(--muted); font-size: 0.92rem; }
+      .card ul { margin: 0.7rem 0 0; padding-left: 1.1rem; }
+      .card li + li { margin-top: 0.3rem; }
+      .tag {
+        display: inline-block;
+        margin-bottom: 0.65rem;
+        padding: 0.25rem 0.55rem;
+        border-radius: 999px;
+        font-size: 0.7rem;
+        font-weight: 800;
+      }
+      .tag.blocker { color: var(--red); background: var(--red-soft); }
+      .tag.required { color: var(--amber); background: var(--amber-soft); }
+      .tag.done { color: var(--green); background: var(--green-soft); }
+      .tag.info { color: var(--blue); background: var(--blue-soft); }
+
+      .status-list { display: grid; gap: 0.55rem; margin-top: 0.8rem; }
+      .status-row {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: 1rem;
+        align-items: center;
+        padding: 0.7rem 0.85rem;
+        border-radius: 11px;
+        background: #f8f9fc;
+        font-size: 0.88rem;
+      }
+      .status { justify-self: end; font-weight: 800; }
+      .status.ok { color: var(--green); }
+      .status.no { color: var(--red); }
+
+      .checks { display: grid; gap: 0.48rem; margin-top: 0.8rem; }
+      .check {
+        display: grid;
+        grid-template-columns: 1.1rem 1fr;
+        gap: 0.55rem;
+        align-items: start;
+        font-size: 0.91rem;
+      }
+      .check input { width: 1rem; height: 1rem; margin: 0.25rem 0 0; accent-color: var(--pink); }
+      .evidence {
+        margin-top: 1rem;
+        padding: 0.85rem 1rem;
+        border-left: 4px solid var(--green);
+        border-radius: 0 10px 10px 0;
+        background: var(--green-soft);
+        font-size: 0.86rem;
+      }
+
+      details {
+        margin-top: 0.9rem;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: #fbfbfd;
+      }
+      summary { cursor: pointer; padding: 0.8rem 0.9rem; font-weight: 800; }
+      details > div { padding: 0 0.9rem 0.9rem; }
+
+      .timeline { display: grid; gap: 0; counter-reset: release; }
+      .step {
+        counter-increment: release;
+        display: grid;
+        grid-template-columns: 2.2rem 1fr;
+        gap: 0.8rem;
+        position: relative;
+        padding-bottom: 1.2rem;
+      }
+      .step::before {
+        content: counter(release);
+        z-index: 1;
+        display: grid;
+        place-items: center;
+        width: 2.2rem;
+        height: 2.2rem;
+        border-radius: 50%;
+        color: white;
+        background: var(--navy);
+        font-size: 0.78rem;
+        font-weight: 900;
+      }
+      .step:not(:last-child)::after {
+        content: "";
+        position: absolute;
+        top: 2rem;
+        left: 1.06rem;
+        bottom: 0;
+        width: 2px;
+        background: var(--line);
+      }
+      .step h4 { margin: 0.15rem 0 0.2rem; }
+      .step p { margin: 0; color: var(--muted); font-size: 0.9rem; }
+
+      .gate { border-top: 5px solid var(--pink); }
+      .sources { display: grid; gap: 0.55rem; padding: 0; list-style: none; }
+      .sources a { display: block; padding: 0.72rem 0.85rem; border-radius: 10px; background: #f7f8fb; text-decoration: none; }
+      footer { padding: 32px 0 50px; color: var(--muted); text-align: center; font-size: 0.82rem; }
+
+      @media (max-width: 760px) {
+        .wrap { width: min(100% - 20px, 1120px); }
+        .hero { padding-top: 18px; }
+        .hero-card { padding: 28px 22px; border-radius: 20px; }
+        .jump { top: 6px; margin-bottom: 20px; }
+        .section-head { align-items: start; flex-direction: column; }
+        .card, .card.third { grid-column: 1 / -1; padding: 18px; }
+        .status-row { grid-template-columns: 1fr; gap: 0.15rem; }
+        .status { justify-self: start; }
+        body { word-break: normal; }
+      }
+
+      @media print {
+        body { background: white; }
+        .jump { display: none; }
+        .hero { padding-top: 0; }
+        .hero-card, .card { box-shadow: none; }
+        .card { break-inside: avoid; }
+        a { color: inherit; text-decoration: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="hero">
+      <div class="wrap">
+        <div class="hero-card">
+          <div class="eyebrow">EUM · iOS RELEASE 1.1.0</div>
+          <h1>App Store 정식 배포 Runbook</h1>
+          <p>백엔드·프론트엔드·PM이 각자 이 문서만 보고 작업하고, 모든 Gate 통과 후 Build 16을 심사 제출·출시하기 위한 실행 문서입니다.</p>
+          <div class="hero-meta">
+            <span>기준일 2026-07-16</span>
+            <span>릴리스 이슈 EUM-133</span>
+            <span>현재 상태 NO-GO</span>
+            <span>최종 대상 Build 16</span>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="wrap">
+      <div class="notice">
+        <div>⚠️</div>
+        <div><strong>Build 14와 15는 최종 제출에 사용하지 않습니다.</strong> 아래 Build 전 Gate를 모두 통과한 뒤, 최종 릴리스 커밋과 수정된 production 환경으로 Build 16을 생성합니다.</div>
+      </div>
+
+      <nav class="jump" aria-label="문서 바로가기">
+        <a href="#status">현재 상태</a>
+        <a href="#backend">백엔드</a>
+        <a href="#frontend">프론트엔드</a>
+        <a href="#pm">PM</a>
+        <a href="#release">배포 순서</a>
+        <a href="#gates">GO / NO-GO</a>
+        <a href="#sources">공식 근거</a>
+      </nav>
+
+      <section id="status">
+        <div class="section-head">
+          <div><h2>현재 상태</h2><p>2026-07-16 실제 환경·코드·운영 응답 재검증 결과</p></div>
+          <span class="owner">Release Owner</span>
+        </div>
+        <div class="grid">
+          <article class="card">
+            <span class="tag done">완료</span>
+            <h3>기술 기반</h3>
+            <div class="status-list">
+              <div class="status-row"><span>Production API URL</span><span class="status ok">/api 포함 수정 완료</span></div>
+              <div class="status-row"><span>WebSocket</span><span class="status ok">운영 핸드셰이크 정상</span></div>
+              <div class="status-row"><span>EAS version</span><span class="status ok">현재 15 → 다음 16</span></div>
+              <div class="status-row"><span>서명·SDK</span><span class="status ok">Xcode/iOS SDK 26</span></div>
+              <div class="status-row"><span>Privacy Manifest·권한</span><span class="status ok">IPA 확인 완료</span></div>
+              <div class="status-row"><span>정적 검증</span><span class="status ok">TS·Doctor·export 통과</span></div>
+            </div>
+          </article>
+          <article class="card">
+            <span class="tag blocker">배포 차단</span>
+            <h3>아직 해결할 항목</h3>
+            <div class="status-list">
+              <div class="status-row"><span>운영 약관</span><span class="status no">items: []</span></div>
+              <div class="status-row"><span>Support / Privacy / Terms</span><span class="status no">공개 URL 404</span></div>
+              <div class="status-row"><span>탈퇴 실제 삭제</span><span class="status no">백엔드 확인 필요</span></div>
+              <div class="status-row"><span>UGC 사전 필터링</span><span class="status no">확인되지 않음</span></div>
+              <div class="status-row"><span>App Review 계정</span><span class="status no">준비 필요</span></div>
+              <div class="status-row"><span>최종 코드·Build 16</span><span class="status no">미병합·미생성</span></div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="backend">
+        <div class="section-head">
+          <div><h2>1. 백엔드 담당</h2><p>운영 데이터, 계정 삭제, UGC 안전장치와 심사용 production 상태를 책임집니다.</p></div>
+          <span class="owner">Backend</span>
+        </div>
+        <div class="grid">
+          <article class="card">
+            <span class="tag blocker">BE-1 · 배포 차단</span>
+            <h3>운영 약관 데이터 등록</h3>
+            <p>PM이 확정한 원문을 production DB에 등록합니다. 앱은 동적 조회하므로 데이터 등록만으로 반영되며 재빌드는 필요 없습니다.</p>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span><code>POLICY</code> 서비스 이용약관 등록</span></label>
+              <label class="check"><input type="checkbox" /> <span><code>PERSONAL_INFORMATION</code> 개인정보처리방침 등록</span></label>
+              <label class="check"><input type="checkbox" /> <span><code>MARKETING</code> 선택 동의 등록 또는 미사용 처리 확인</span></label>
+              <label class="check"><input type="checkbox" /> <span><code>GET /api/v1/agreements</code>가 200이며 각 항목에 agreementId·type·body 포함</span></label>
+              <label class="check"><input type="checkbox" /> <span>신규 계정에서 약관 표시 → 필수 동의 → 다음 화면 진입</span></label>
+              <label class="check"><input type="checkbox" /> <span>개인정보처리방침 상세가 빈 화면이 아님</span></label>
+            </div>
+            <div class="evidence"><strong>완료 증빙:</strong> 약관 API 응답과 신규 계정 온보딩 성공 화면</div>
+          </article>
+
+          <article class="card">
+            <span class="tag blocker">BE-2 · 배포 차단</span>
+            <h3>회원탈퇴가 실제 삭제를 보장하는지 확인</h3>
+            <p>현재 앱은 <code>PATCH /api/v1/users/me/deactivate</code>를 호출합니다. 단순 휴면이 아니라 삭제 또는 삭제 예약이어야 합니다.</p>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>access/refresh token과 서버 세션 무효화</span></label>
+              <label class="check"><input type="checkbox" /> <span>푸시 토큰 해제</span></label>
+              <label class="check"><input type="checkbox" /> <span>Apple/Kakao 연결 식별자 처리</span></label>
+              <label class="check"><input type="checkbox" /> <span>프로필·사진·음성 등 개인정보 삭제 또는 삭제 예약</span></label>
+              <label class="check"><input type="checkbox" /> <span>법적 보관 데이터·기간·사유 문서화</span></label>
+              <label class="check"><input type="checkbox" /> <span>재로그인 시 기존 계정이 그대로 복구되지 않음</span></label>
+            </div>
+            <div class="evidence"><strong>완료 증빙:</strong> 테스트 계정 탈퇴 결과와 데이터 보관/삭제 정책</div>
+          </article>
+
+          <article class="card">
+            <span class="tag blocker">BE-3 · 추가 심사 위험</span>
+            <h3>UGC 필터링과 신고 운영 체계</h3>
+            <p>신고·차단 UI는 확인됐지만 Apple은 게시 전 필터링과 운영 대응도 요구합니다. 기존 시스템이 있으면 새로 만들지 말고 작동 증거만 제출합니다.</p>
+            <h4>적용 대상</h4>
+            <ul>
+              <li>프로필 닉네임·소개</li>
+              <li>채팅 텍스트·사진·음성</li>
+              <li>동호회 이름·설명</li>
+              <li>게시글·댓글·첨부 이미지</li>
+            </ul>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>금칙어·혐오·성적·불법 콘텐츠 제한 정책/구현</span></label>
+              <label class="check"><input type="checkbox" /> <span>이미지·음성 등 비텍스트 검토 방식</span></label>
+              <label class="check"><input type="checkbox" /> <span>신고가 관리자 확인 목록에 적재</span></label>
+              <label class="check"><input type="checkbox" /> <span>콘텐츠 삭제·사용자 제재·반복 위반 처리 가능</span></label>
+              <label class="check"><input type="checkbox" /> <span>신고 처리 담당자와 목표 시간 확정</span></label>
+            </div>
+          </article>
+
+          <article class="card">
+            <span class="tag required">BE-4 · 운영 준비</span>
+            <h3>Production 핵심 경로와 심사용 데이터</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>Apple/Kakao 로그인과 refresh token 회전 성공</span></label>
+              <label class="check"><input type="checkbox" /> <span>사진·음성 업로드와 음성 분석 성공</span></label>
+              <label class="check"><input type="checkbox" /> <span>추천·마음·프로필·동호회 데이터 조회</span></label>
+              <label class="check"><input type="checkbox" /> <span>채팅 연결과 네트워크 복구 후 재연결</span></label>
+              <label class="check"><input type="checkbox" /> <span>신고·차단·탈퇴 API 성공</span></label>
+              <label class="check"><input type="checkbox" /> <span>심사용 가상 데이터 준비 및 심사 기간 DB 초기화 금지</span></label>
+              <label class="check"><input type="checkbox" /> <span>장애 알림과 대응 담당자 연락망 준비</span></label>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="frontend">
+        <div class="section-head">
+          <div><h2>2. 프론트엔드 담당</h2><p>최종 코드, 공개 링크, EAS Build 16과 실제 바이너리 스모크를 책임집니다.</p></div>
+          <span class="owner">Frontend</span>
+        </div>
+        <div class="grid">
+          <article class="card">
+            <span class="tag required">FE-1 · 코드 마감</span>
+            <h3>남은 코드 반영</h3>
+            <p><code>chore/EUM-133-ios-appstore-release</code> / 기준 <code>a73b1bb</code>. 현재 원격보다 2커밋 앞서고 axios timeout 수정이 미커밋 상태입니다.</p>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>axios 전역 15초 timeout 제거 확인</span></label>
+              <label class="check"><input type="checkbox" /> <span>refresh 요청 자체의 15초 timeout 유지</span></label>
+              <label class="check"><input type="checkbox" /> <span>마이페이지 고객지원 → <code>/support</code> 외부 페이지</span></label>
+              <label class="check"><input type="checkbox" /> <span>개인정보처리방침 → 앱 내부 또는 <code>/privacy</code></span></label>
+              <label class="check"><input type="checkbox" /> <span>서비스 이용약관 상세 정상 표시</span></label>
+              <label class="check"><input type="checkbox" /> <span>빈 URL을 숨기던 임시 상태 제거</span></label>
+            </div>
+          </article>
+
+          <article class="card">
+            <span class="tag required">FE-2 · Git/검증</span>
+            <h3>PR과 재현 가능한 소스</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>변경 커밋 및 릴리스 브랜치 push</span></label>
+              <label class="check"><input type="checkbox" /> <span>dev 대상 PR 생성·리뷰·병합</span></label>
+              <label class="check"><input type="checkbox" /> <span>EAS 빌드 커밋이 원격에 존재</span></label>
+              <label class="check"><input type="checkbox" /> <span>릴리스 worktree clean</span></label>
+            </div>
+            <pre><code>pnpm install --frozen-lockfile
+pnpm exec tsc --noEmit
+pnpm dlx expo-doctor
+pnpm lint</code></pre>
+            <p>현재 허용 결과: lint 오류 0, 기존 경고 3건.</p>
+          </article>
+
+          <article class="card wide">
+            <span class="tag required">FE-3 · EAS Build 16</span>
+            <h3>production 환경 확인 후 생성·업로드</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span><code>EXPO_PUBLIC_API_BASE_URL</code>에 서버 <code>/api</code> prefix 포함</span></label>
+              <label class="check"><input type="checkbox" /> <span>production WebSocket origin과 Kakao 설정 확인</span></label>
+              <label class="check"><input type="checkbox" /> <span>local .env가 EAS production 값을 덮어쓰지 않음</span></label>
+            </div>
+            <pre><code>pnpm dlx eas-cli env:list production --format long
+pnpm dlx eas-cli build:version:get --platform ios --profile production --non-interactive
+
+pnpm dlx eas-cli build \
+  --platform ios \
+  --profile production \
+  --auto-submit \
+  --message "App Store release 1.1.0 (16)" \
+  --wait</code></pre>
+            <details>
+              <summary>Build 16 완료 기준</summary>
+              <div class="checks">
+                <label class="check"><input type="checkbox" /> <span>Build status <code>FINISHED</code></span></label>
+                <label class="check"><input type="checkbox" /> <span>Version <code>1.1.0</code> / Build <code>16</code></span></label>
+                <label class="check"><input type="checkbox" /> <span>Git commit이 최종 릴리스 커밋</span></label>
+                <label class="check"><input type="checkbox" /> <span>EAS Submission <code>FINISHED</code></span></label>
+                <label class="check"><input type="checkbox" /> <span>App Store Connect <code>Ready to Submit</code></span></label>
+                <label class="check"><input type="checkbox" /> <span>Missing Compliance·업로드 경고 없음</span></label>
+              </div>
+            </details>
+          </article>
+
+          <article class="card wide">
+            <span class="tag blocker">FE-4 · 최종 보증</span>
+            <h3>Build 16 실기기 스모크</h3>
+            <p>TestFlight 베타 운영은 생략할 수 있지만, Build 16 자체를 내부 TestFlight에서 한 번 확인해야 런타임 반려 위험을 낮출 수 있습니다.</p>
+            <div class="grid" style="margin-top: 12px">
+              <div class="card third">
+                <h4>설치·인증</h4>
+                <div class="checks">
+                  <label class="check"><input type="checkbox" /> <span>완전 삭제 후 신규 설치</span></label>
+                  <label class="check"><input type="checkbox" /> <span>Apple/Kakao 로그인</span></label>
+                  <label class="check"><input type="checkbox" /> <span>약관과 전체 온보딩</span></label>
+                  <label class="check"><input type="checkbox" /> <span>재실행과 refresh</span></label>
+                </div>
+              </div>
+              <div class="card third">
+                <h4>핵심 기능</h4>
+                <div class="checks">
+                  <label class="check"><input type="checkbox" /> <span>사진·마이크 권한</span></label>
+                  <label class="check"><input type="checkbox" /> <span>음성 녹음·업로드·분석</span></label>
+                  <label class="check"><input type="checkbox" /> <span>채팅 재연결</span></label>
+                  <label class="check"><input type="checkbox" /> <span>신고·차단</span></label>
+                </div>
+              </div>
+              <div class="card third">
+                <h4>배포 경로</h4>
+                <div class="checks">
+                  <label class="check"><input type="checkbox" /> <span>오프라인 무한 대기 없음</span></label>
+                  <label class="check"><input type="checkbox" /> <span>Support/Privacy 링크</span></label>
+                  <label class="check"><input type="checkbox" /> <span>복제 계정 탈퇴</span></label>
+                  <label class="check"><input type="checkbox" /> <span>크래시·흰 화면 없음</span></label>
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="pm">
+        <div class="section-head">
+          <div><h2>3. PM / 배포 담당</h2><p>법무·웹페이지·심사 계정·App Store Connect 등록과 실제 출시를 책임집니다.</p></div>
+          <span class="owner">PM · App Manager</span>
+        </div>
+        <div class="grid">
+          <article class="card">
+            <span class="tag blocker">PM-1 · 배포 차단</span>
+            <h3>법무 문서와 공개 웹페이지</h3>
+            <p>권장 주소: <code>/support</code>, <code>/privacy</code>, <code>/terms</code></p>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>HTTPS·로그인 없이 접근·모바일 대응</span></label>
+              <label class="check"><input type="checkbox" /> <span>운영 주체와 실제 문의 이메일/전화/폼</span></label>
+              <label class="check"><input type="checkbox" /> <span>수집·이용·보관·삭제와 제3자 제공/위탁</span></label>
+              <label class="check"><input type="checkbox" /> <span>Apple/Kakao/Firebase/스토리지 반영</span></label>
+              <label class="check"><input type="checkbox" /> <span>계정 삭제, 신고·차단, 고객지원 안내</span></label>
+              <label class="check"><input type="checkbox" /> <span>시행일·개정일, 깨진 링크·임시 문구 없음</span></label>
+            </div>
+          </article>
+
+          <article class="card">
+            <span class="tag blocker">PM-2 · 배포 차단</span>
+            <h3>App Review 데모 계정</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>2FA/SMS/특정 기기 승인 없는 테스트 소셜 계정</span></label>
+              <label class="check"><input type="checkbox" /> <span>온보딩 완료 및 가상 프로필</span></label>
+              <label class="check"><input type="checkbox" /> <span>추천·마음·채팅·동호회 검토 데이터</span></label>
+              <label class="check"><input type="checkbox" /> <span>실제 사용자 개인정보 없음</span></label>
+              <label class="check"><input type="checkbox" /> <span>심사 기간 계정·비밀번호·데이터 유지</span></label>
+              <label class="check"><input type="checkbox" /> <span>로그인과 주요 기능 경로 문서화</span></label>
+            </div>
+            <p>소셜 계정 제공이 불가능하면 보안 검토된 심사용 로그인을 마련합니다. 보호되지 않은 production test-login을 노출하지 않습니다.</p>
+          </article>
+
+          <article class="card">
+            <span class="tag required">PM-3 · App Information</span>
+            <h3>앱 공통 정보와 규정</h3>
+            <p>App Store Connect → My Apps → 이음 → General → App Information</p>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>앱 이름·부제·언어·카테고리</span></label>
+              <label class="check"><input type="checkbox" /> <span>Content Rights</span></label>
+              <label class="check"><input type="checkbox" /> <span>새 연령 등급 설문 — UGC·채팅을 정직하게 응답</span></label>
+              <label class="check"><input type="checkbox" /> <span>서비스 최소 연령보다 낮으면 상향 Override 검토</span></label>
+              <label class="check"><input type="checkbox" /> <span>Privacy Policy URL</span></label>
+              <label class="check"><input type="checkbox" /> <span>대한민국 규정/연락처 항목</span></label>
+              <label class="check"><input type="checkbox" /> <span>EU DSA trader/non-trader 상태 선언·필요 시 연락처 검증</span></label>
+            </div>
+          </article>
+
+          <article class="card">
+            <span class="tag required">PM-4 · App Privacy</span>
+            <h3>데이터 수집 답변 작성·Publish</h3>
+            <p>앱·서버·제3자 SDK가 수집하는 데이터를 함께 확인합니다.</p>
+            <details open>
+              <summary>확인할 데이터 후보</summary>
+              <div>
+                <ul>
+                  <li>이름·이메일, 생년/연령·성별·지역</li>
+                  <li>프로필 사진·음성, 채팅·게시글·댓글</li>
+                  <li>사용자 ID, 푸시 토큰/기기 정보</li>
+                  <li>추천·마음·프로필 방문·동호회 활동</li>
+                  <li>신고·차단 기록과 Firebase 등 제3자 SDK 데이터</li>
+                </ul>
+              </div>
+            </details>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>각 항목의 수집·계정 연결·사용 목적·제3자 제공 답변</span></label>
+              <label class="check"><input type="checkbox" /> <span>실제 데이터 흐름과 개인정보처리방침 일치</span></label>
+              <label class="check"><input type="checkbox" /> <span>광고/추적 여부 사실 확인</span></label>
+              <label class="check"><input type="checkbox" /> <span>App Privacy <strong>Publish</strong> 완료</span></label>
+            </div>
+          </article>
+
+          <article class="card wide">
+            <span class="tag required">PM-5 · 버전 메타데이터와 심사 정보</span>
+            <h3>iOS 1.1.0 제출 화면 완성</h3>
+            <div class="grid" style="margin-top: 12px">
+              <div class="card third">
+                <h4>Product Page</h4>
+                <div class="checks">
+                  <label class="check"><input type="checkbox" /> <span>실제 앱 스크린샷</span></label>
+                  <label class="check"><input type="checkbox" /> <span>설명·키워드</span></label>
+                  <label class="check"><input type="checkbox" /> <span>Support URL</span></label>
+                  <label class="check"><input type="checkbox" /> <span>Copyright</span></label>
+                  <label class="check"><input type="checkbox" /> <span>실제 개인정보·Android 화면 없음</span></label>
+                </div>
+              </div>
+              <div class="card third">
+                <h4>Availability</h4>
+                <div class="checks">
+                  <label class="check"><input type="checkbox" /> <span>Build 16 선택</span></label>
+                  <label class="check"><input type="checkbox" /> <span>국가/지역·가격</span></label>
+                  <label class="check"><input type="checkbox" /> <span>수출 규정 상태</span></label>
+                  <label class="check"><input type="checkbox" /> <span>수동 출시 선택</span></label>
+                  <label class="check"><input type="checkbox" /> <span>계약·법적 배너 없음</span></label>
+                </div>
+              </div>
+              <div class="card third">
+                <h4>App Review Information</h4>
+                <div class="checks">
+                  <label class="check"><input type="checkbox" /> <span>담당자 이름·이메일·전화</span></label>
+                  <label class="check"><input type="checkbox" /> <span>데모 계정</span></label>
+                  <label class="check"><input type="checkbox" /> <span>로그인·핵심 기능 경로</span></label>
+                  <label class="check"><input type="checkbox" /> <span>권한 사용 이유</span></label>
+                  <label class="check"><input type="checkbox" /> <span>신고·차단·탈퇴 위치</span></label>
+                </div>
+              </div>
+            </div>
+            <details>
+              <summary>Review Notes에 적을 내용</summary>
+              <div>
+                <ul>
+                  <li>앱 목적과 50세 이상 대상 서비스</li>
+                  <li>Apple/Kakao 로그인과 데모 계정 사용 순서</li>
+                  <li>음성 프로필 녹음을 위한 마이크 권한</li>
+                  <li>프로필/게시물을 위한 카메라·사진 권한</li>
+                  <li>신고·차단 위치와 회원탈퇴 경로: 마이페이지 → 탈퇴하기</li>
+                  <li>고객지원·개인정보처리방침 위치, 결제/IAP 유무</li>
+                </ul>
+              </div>
+            </details>
+          </article>
+
+          <article class="card wide">
+            <span class="tag info">PM-6 · 계정·계약</span>
+            <h3>Account Holder / Admin 확인</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>Apple Developer Program 계약 최신, 상단 미동의 법적 고지 없음</span></label>
+              <label class="check"><input type="checkbox" /> <span>Account Holder 정보·연락처 최신</span></label>
+              <label class="check"><input type="checkbox" /> <span>유료/IAP가 있다면 Paid Apps Agreement·세금·은행 정보 완료</span></label>
+              <label class="check"><input type="checkbox" /> <span>무료·IAP 없음이면 불필요한 유료 계약을 차단 조건으로 잡지 않음</span></label>
+              <label class="check"><input type="checkbox" /> <span>DSA 상태와 대한민국 배포 규정 확인</span></label>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="release">
+        <div class="section-head">
+          <div><h2>4. 실제 배포 순서</h2><p>선행 조건을 지켜야 재빌드와 심사 반려를 피할 수 있습니다.</p></div>
+          <span class="owner">Release Owner</span>
+        </div>
+        <article class="card wide">
+          <div class="timeline">
+            <div class="step"><div><h4>백엔드·PM 차단 항목 완료</h4><p>약관, 탈퇴, UGC, 공개 페이지, 데모 계정을 먼저 끝냅니다.</p></div></div>
+            <div class="step"><div><h4>프론트 URL 연결·코드 병합</h4><p>릴리스 브랜치 push, dev PR 병합, clean worktree를 확인합니다.</p></div></div>
+            <div class="step"><div><h4>Build 16 생성·자동 업로드</h4><p>EAS Build와 Submission이 모두 FINISHED인지 확인합니다.</p></div></div>
+            <div class="step"><div><h4>Build 16 실기기 스모크</h4><p>내부 TestFlight 한 회로 설치·인증·온보딩·핵심 기능을 확인합니다.</p></div></div>
+            <div class="step"><div><h4>App Store Connect 완성</h4><p>메타데이터, App Privacy, 연령 등급, 규정, Review Information을 채웁니다.</p></div></div>
+            <div class="step"><div><h4>Add for Review → Submit for Review</h4><p>Build 16을 선택하고 Draft Submissions에서 실제 심사를 제출합니다.</p></div></div>
+            <div class="step"><div><h4>심사 대응</h4><p>Waiting for Review → In Review를 모니터링하고 메시지에 즉시 답합니다.</p></div></div>
+            <div class="step"><div><h4>수동 출시</h4><p>Pending Developer Release에서 Release This Version을 누릅니다.</p></div></div>
+            <div class="step"><div><h4>실제 노출 확인</h4><p>App Store 검색·설치·로그인을 확인하고 EUM-133을 닫습니다.</p></div></div>
+          </div>
+        </article>
+      </section>
+
+      <section id="gates">
+        <div class="section-head">
+          <div><h2>5. 최종 GO / NO-GO Gate</h2><p>하나라도 비어 있으면 다음 단계로 넘어가지 않습니다.</p></div>
+          <span class="owner">ALL OWNERS</span>
+        </div>
+        <div class="grid">
+          <article class="card third gate">
+            <h3>Gate A · Build 전</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>약관 데이터 정상</span></label>
+              <label class="check"><input type="checkbox" /> <span>탈퇴 의미 확인</span></label>
+              <label class="check"><input type="checkbox" /> <span>UGC 필터링·신고 운영</span></label>
+              <label class="check"><input type="checkbox" /> <span>Support/Privacy 200</span></label>
+              <label class="check"><input type="checkbox" /> <span>데모 계정</span></label>
+              <label class="check"><input type="checkbox" /> <span>URL 연결·PR 병합</span></label>
+              <label class="check"><input type="checkbox" /> <span>EAS production 확인</span></label>
+            </div>
+          </article>
+          <article class="card third gate">
+            <h3>Gate B · 심사 제출 전</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>Build/Submission 16 완료</span></label>
+              <label class="check"><input type="checkbox" /> <span>Ready to Submit</span></label>
+              <label class="check"><input type="checkbox" /> <span>실기기 스모크</span></label>
+              <label class="check"><input type="checkbox" /> <span>App Privacy Publish</span></label>
+              <label class="check"><input type="checkbox" /> <span>연령 등급·메타데이터</span></label>
+              <label class="check"><input type="checkbox" /> <span>Review 계정·Notes</span></label>
+              <label class="check"><input type="checkbox" /> <span>DSA·계약·규정</span></label>
+            </div>
+          </article>
+          <article class="card third gate">
+            <h3>Gate C · 완전 배포</h3>
+            <div class="checks">
+              <label class="check"><input type="checkbox" /> <span>Submit for Review</span></label>
+              <label class="check"><input type="checkbox" /> <span>심사 승인</span></label>
+              <label class="check"><input type="checkbox" /> <span>Pending Developer Release</span></label>
+              <label class="check"><input type="checkbox" /> <span>Release This Version</span></label>
+              <label class="check"><input type="checkbox" /> <span>App Store 실제 설치</span></label>
+              <label class="check"><input type="checkbox" /> <span>운영 모니터링 담당 대기</span></label>
+              <label class="check"><input type="checkbox" /> <span>EUM-133 종료</span></label>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="sources">
+        <div class="section-head">
+          <div><h2>6. 공식 검증 근거</h2><p>Apple·Expo 공식 문서만 사용했습니다.</p></div>
+        </div>
+        <article class="card wide">
+          <ul class="sources">
+            <li><a href="https://developer.apple.com/app-store/review/guidelines/">Apple App Review Guidelines ↗</a></li>
+            <li><a href="https://developer.apple.com/help/app-store-connect/manage-app-information/manage-app-privacy/">App Privacy 관리 ↗</a></li>
+            <li><a href="https://developer.apple.com/help/app-store-connect/manage-app-information/set-an-app-age-rating/">연령 등급 설정 ↗</a></li>
+            <li><a href="https://developer.apple.com/help/app-store-connect/reference/app-information/platform-version-information">버전 메타데이터와 App Review Information ↗</a></li>
+            <li><a href="https://developer.apple.com/help/app-store-connect/manage-compliance-information/manage-european-union-digital-services-act-trader-requirements">EU DSA trader 요구사항 ↗</a></li>
+            <li><a href="https://developer.apple.com/help/app-store-connect/manage-submissions-to-app-review/submit-an-app">App Review 제출 절차 ↗</a></li>
+            <li><a href="https://developer.apple.com/help/app-store-connect/manage-your-apps-availability/select-an-app-store-version-release-option/">수동 출시 절차 ↗</a></li>
+            <li><a href="https://docs.expo.dev/submit/ios/">EAS iOS 제출 ↗</a></li>
+          </ul>
+        </article>
+      </section>
+    </main>
+
+    <footer>
+      <div class="wrap">EUM iOS Release Runbook · EUM-133 · standalone HTML</div>
+    </footer>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-preset-expo": "~54.0.10",
     "commitizen": "^4.3.1",
     "cz-customizable": "^7.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       '@types/react':
         specifier: ~19.1.0
         version: 19.1.17
+      babel-plugin-transform-remove-console:
+        specifier: ^6.9.4
+        version: 6.9.4
       babel-preset-expo:
         specifier: ~54.0.10
         version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.36)(react-refresh@0.14.2)
@@ -2156,6 +2159,9 @@ packages:
 
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
+
+  babel-plugin-transform-remove-console@6.9.4:
+    resolution: {integrity: sha512-88blrUrMX3SPiGkT1GnvVY8E/7A+k6oj3MNvUtTIxJflFzXTw1bHkuJ/y039ouhFMp2prRn5cQGzokViYi1dsg==}
 
   babel-preset-current-node-syntax@1.2.0:
     resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
@@ -8036,6 +8042,8 @@ snapshots:
       '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
+
+  babel-plugin-transform-remove-console@6.9.4: {}
 
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
     dependencies:


### PR DESCRIPTION
## 변경 사항
- 동시 401 token refresh single-flight 및 socket reconnect 토큰 갱신
- refresh 요청 timeout 유지, 전역 Axios timeout 제거
- production console.log 제거
- iOS/Android 스토어 정식 배포 Runbook 추가
- Android 권한과 Google Play 정책 2회 교차검증 결과 반영

## 검증
- pnpm install --frozen-lockfile
- pnpm exec tsc --noEmit
- pnpm lint: 오류 0, 기존 경고 3
- npx expo-doctor: 18/18
- Android production export 성공
- production API 및 WebSocket URL 번들 포함 확인
- READ_MEDIA_IMAGES/VIDEO 미선언, 미사용 특수 권한 제거 확인

Refs #189