### PR TITLE
fix: 계정 탈퇴 API 연동 수정

### DIFF
--- a/api/users/usersApi.ts
+++ b/api/users/usersApi.ts
@@ -6,6 +6,7 @@ import { IUserProfile, IUserPublicProfile } from "../../types/user";
 import {
   IActiveUsersParams,
   IActiveUsersResponse,
+  IDeleteAccountRequest,
   IKeywordsRequest,
   ILikedClubsParams,
   ILikedClubsResponse,
@@ -52,11 +53,11 @@ export const updateMyProfile = async (body: IPatchUserProfileRequest) => {
 
   return data.success.data;
 };
-//v1/users/me/deactivate(patch)
-export const deactivateUser = async () => {
-  const { data } = await api.patch<ApiSuccessResponse<null>>(
-    "/v1/users/me/deactivate",
-  );
+//v1/users/me(delete)
+export const deleteAccount = async (body: IDeleteAccountRequest = {}) => {
+  const { data } = await api.delete<ApiSuccessResponse<null>>("/v1/users/me", {
+    data: body,
+  });
 
   return data.success.data;
 };

--- a/app/(tabs)/my.tsx
+++ b/app/(tabs)/my.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import * as AppleAuthentication from "expo-apple-authentication";
 import { useRouter } from "expo-router";
 import { useCallback, useState } from "react";
 import {
@@ -22,9 +23,10 @@ import { useLogoutMutation } from "@/hooks/api/useAuth";
 import { useRecommendationsInfiniteQuery } from "@/hooks/api/useRecommendations";
 import { useReceivedHeartsInfiniteQuery } from "@/hooks/api/useSocials";
 import {
-  useDeactivateUserMutation,
+  useDeleteAccountMutation,
   useMyProfileQuery,
 } from "@/hooks/api/useUsers";
+import { useAuthStore } from "@/stores/authStore";
 import { useNotificationSettingsStore } from "@/stores/notificationSettingsStore";
 import { uniqueBy } from "@/utils/array";
 
@@ -48,7 +50,8 @@ export default function MyTabScreen() {
   const recommendationsQuery = useRecommendationsInfiniteQuery();
   const myClubsQuery = useMyClubsQuery();
   const logoutMutation = useLogoutMutation();
-  const deactivateUserMutation = useDeactivateUserMutation();
+  const deleteAccountMutation = useDeleteAccountMutation();
+  const authProvider = useAuthStore((state) => state.provider);
   const [isPullRefreshing, setIsPullRefreshing] = useState(false);
 
   // 홈 추천(recommendations)은 1시간 유지 정책이라 수동 새로고침 대상에서 제외한다.
@@ -102,16 +105,50 @@ export default function MyTabScreen() {
   };
 
   const handleDeactivate = () => {
+    if (deleteAccountMutation.isPending) return;
+
     Alert.alert("탈퇴하기", "정말 탈퇴하시겠어요?", [
       { text: "취소", style: "cancel" },
       {
         text: "탈퇴",
         style: "destructive",
-        onPress: () =>
-          deactivateUserMutation.mutate(undefined, {
-            onSuccess: () => router.replace("/onboarding/login" as never),
-            onError: () => Alert.alert("탈퇴 실패", "다시 시도해주세요."),
-          }),
+        onPress: async () => {
+          let appleAuthorizationCode: string | undefined;
+
+          if (authProvider === "APPLE") {
+            try {
+              const credential = await AppleAuthentication.signInAsync({
+                requestedScopes: [],
+              });
+              appleAuthorizationCode = credential.authorizationCode ?? undefined;
+            } catch (error) {
+              if ((error as { code?: string }).code === "ERR_REQUEST_CANCELED") {
+                return;
+              }
+              Alert.alert(
+                "Apple 인증 실패",
+                "탈퇴를 위해 Apple 인증을 다시 진행해주세요.",
+              );
+              return;
+            }
+
+            if (!appleAuthorizationCode) {
+              Alert.alert(
+                "Apple 인증 실패",
+                "Apple 인증 코드를 가져오지 못했어요.",
+              );
+              return;
+            }
+          }
+
+          deleteAccountMutation.mutate(
+            { appleAuthorizationCode },
+            {
+              onSuccess: () => router.replace("/onboarding/login" as never),
+              onError: () => Alert.alert("탈퇴 실패", "다시 시도해주세요."),
+            },
+          );
+        },
       },
     ]);
   };
@@ -344,10 +381,10 @@ export default function MyTabScreen() {
           style={styles.withdrawCard}
           activeOpacity={0.7}
           onPress={handleDeactivate}
-          disabled={deactivateUserMutation.isPending}
+          disabled={deleteAccountMutation.isPending}
         >
           <Text style={styles.withdrawText}>
-            {deactivateUserMutation.isPending ? "탈퇴 처리 중..." : "탈퇴하기"}
+            {deleteAccountMutation.isPending ? "탈퇴 처리 중..." : "탈퇴하기"}
           </Text>
         </TouchableOpacity>
       </ScrollView>

--- a/hooks/api/useAuth.ts
+++ b/hooks/api/useAuth.ts
@@ -30,7 +30,7 @@ export function useKakaoLoginMutation() {
       }
 
       queryClient.removeQueries();
-      setAuth(data);
+      setAuth(data, "KAKAO");
     },
   });
 }
@@ -47,7 +47,7 @@ export function useAppleLoginMutation() {
       }
 
       queryClient.removeQueries();
-      setAuth(data);
+      setAuth(data, "APPLE");
     },
   });
 }
@@ -90,7 +90,7 @@ export function useTestLoginMutation() {
       }
 
       queryClient.removeQueries();
-      setAuth(data);
+      setAuth(data, "LOCAL");
     },
   });
 }

--- a/hooks/api/useUsers.ts
+++ b/hooks/api/useUsers.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   createProfileVisit,
-  deactivateUser,
+  deleteAccount,
   getActiveUsers,
   getLikedClubs,
   getMyProfile,
@@ -23,6 +23,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { removePushTokenFromServer } from "@/utils/pushNotifications";
 import {
   IActiveUsersParams,
+  IDeleteAccountRequest,
   IKeywordsRequest,
   ILikedClubsParams,
   IMyProfileVisitorsRequest,
@@ -122,15 +123,15 @@ export function useUpdateMyProfileMutation() {
   });
 }
 
-export function useDeactivateUserMutation() {
+export function useDeleteAccountMutation() {
   const queryClient = useQueryClient();
   const clearAuth = useAuthStore((state) => state.clearAuth);
 
   return useMutation({
     // 인증이 남아있을 때 푸시 토큰 먼저 해제한 뒤 탈퇴
-    mutationFn: async () => {
+    mutationFn: async (body: IDeleteAccountRequest = {}) => {
       await removePushTokenFromServer();
-      return deactivateUser();
+      return deleteAccount(body);
     },
     onSuccess: () => {
       disconnectChatSocket();

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -2,10 +2,12 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 import { IKakaoLoginResponse } from "@/types/api/auth/authDTO";
+import { AuthProvider, getAuthProviderFromToken } from "@/utils/authToken";
 import { safeAsyncStorage } from "@/utils/safeAsyncStorage";
 
 interface AuthState {
   accessToken: string | null;
+  provider: AuthProvider | null;
   user: IKakaoLoginResponse["user"] | null;
   isNewUser: boolean;
   onboardingRequired: boolean;
@@ -13,7 +15,7 @@ interface AuthState {
   isAuthInitialized: boolean;
   setAccessToken: (accessToken: string | null) => void;
   setUser: (user: AuthState["user"]) => void;
-  setAuth: (payload: IKakaoLoginResponse) => void;
+  setAuth: (payload: IKakaoLoginResponse, provider?: AuthProvider) => void;
   setAuthInitialized: (isAuthInitialized: boolean) => void;
   completeOnboarding: () => void;
   clearAuth: () => void;
@@ -23,6 +25,7 @@ export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       accessToken: null,
+      provider: null,
       user: null,
       isNewUser: false,
       onboardingRequired: false,
@@ -31,12 +34,14 @@ export const useAuthStore = create<AuthState>()(
       setAccessToken: (accessToken) =>
         set({
           accessToken,
+          provider: getAuthProviderFromToken(accessToken),
           isAuthenticated: !!accessToken,
         }),
       setUser: (user) => set({ user }),
-      setAuth: (payload) =>
+      setAuth: (payload, provider) =>
         set({
           accessToken: payload.accessToken,
+          provider: provider ?? getAuthProviderFromToken(payload.accessToken),
           user: payload.user,
           isNewUser: payload.isNewUser,
           onboardingRequired: payload.onboardingRequired,
@@ -55,6 +60,7 @@ export const useAuthStore = create<AuthState>()(
       clearAuth: () =>
         set({
           accessToken: null,
+          provider: null,
           user: null,
           isNewUser: false,
           onboardingRequired: false,

--- a/types/api/users/usersDTO.ts
+++ b/types/api/users/usersDTO.ts
@@ -12,6 +12,10 @@ export interface IPatchUserProfileRequest {
   profileImageUrl?: string;
 }
 
+export interface IDeleteAccountRequest {
+  appleAuthorizationCode?: string;
+}
+
 export interface IKeywordsRequest {
   interestKeywordIds: number[];
 }

--- a/utils/authToken.ts
+++ b/utils/authToken.ts
@@ -1,0 +1,46 @@
+export type AuthProvider = "APPLE" | "KAKAO" | "LOCAL" | (string & {});
+
+type AuthTokenPayload = {
+  provider?: string;
+};
+
+const BASE64_URL_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+function decodeBase64Url(input: string) {
+  let buffer = 0;
+  let bits = 0;
+  let output = "";
+
+  for (const char of input.replace(/=+$/, "")) {
+    const value = BASE64_URL_ALPHABET.indexOf(char);
+    if (value < 0) continue;
+
+    buffer = (buffer << 6) | value;
+    bits += 6;
+
+    if (bits >= 8) {
+      bits -= 8;
+      output += String.fromCharCode((buffer >> bits) & 0xff);
+    }
+  }
+
+  return output;
+}
+
+export function getAuthProviderFromToken(token: string | null) {
+  if (!token) return null;
+
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+
+  try {
+    const parsed = JSON.parse(decodeBase64Url(payload)) as AuthTokenPayload;
+    const provider = parsed.provider?.toUpperCase() as
+      | AuthProvider
+      | undefined;
+    return provider ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용
- 어떤 기능을 개발/수정했는지 요약해주세요.

## 🔍 관련 이슈
- #이슈번호

## 🖼️ 스크린샷
- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.

## 🧪 테스트 결과
- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 계정 탈퇴 방식이 개선되었습니다.
  - Apple 계정 사용자는 탈퇴 시 Apple 인증을 추가로 진행해야 합니다.
  - 탈퇴 요청에 필요한 인증 정보를 안전하게 처리합니다.

- **개선 사항**
  - 탈퇴 처리 중 버튼이 비활성화되고 진행 상태가 표시됩니다.
  - 로그인 제공자 정보가 안정적으로 관리되어 인증 흐름이 개선되었습니다.

- **버그 수정**
  - 계정 탈퇴 후 인증 정보, 푸시 알림 등록, 채팅 연결 및 앱 캐시가 정상적으로 정리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->