### PR TITLE
[EUM-190] fix: 앱 UI 오류 처리 및 정책 링크 개선

### DIFF
--- a/api/axiosInstance.ts
+++ b/api/axiosInstance.ts
@@ -1,4 +1,9 @@
-import axios, { AxiosError, AxiosRequestConfig, create } from "axios";
+import axios, {
+  AxiosError,
+  AxiosRequestConfig,
+  create,
+  isAxiosError,
+} from "axios";
 import { getAuthAccessToken, useAuthStore } from "../stores/authStore";
 import { ApiFailResponse, ApiSuccessResponse } from "../types/api/api";
 import { ITokenRefreshResponse } from "../types/api/auth/authDTO";
@@ -22,6 +27,11 @@ const normalizedBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL?.replace(
   "",
 );
 const REFRESH_TOKEN_PATH = "/v1/auth/token/refresh";
+
+export const getApiErrorMessage = (error: unknown) =>
+  isAxiosError<ApiFailResponse>(error)
+    ? error.response?.data?.error?.message
+    : undefined;
 
 const api = create({
   baseURL: normalizedBaseUrl,

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -37,7 +37,7 @@ export default function TabLayout() {
         const currentRouteName = props.state.routes[props.state.index].name;
 
         return (
-          <View style={styles.tabBar}>
+          <View pointerEvents="box-none" style={styles.tabBar}>
             <AppNavbar
               activeTabId={currentRouteName}
               onTabPress={(id) => {
@@ -83,5 +83,6 @@ const styles = StyleSheet.create({
   // 높이는 Navbar가 safe-area inset을 포함해 스스로 결정하므로 고정하지 않는다.
   tabBar: {
     backgroundColor: "#FFFFFF",
+    zIndex: 1,
   },
 });

--- a/app/(tabs)/my.tsx
+++ b/app/(tabs)/my.tsx
@@ -34,8 +34,9 @@ const ACCENT = "#FC3367";
 const TEXT = "#202020";
 const SUB_TEXT = "#636970";
 const MUTED = "#A6AFB6";
-// ponytail: 고객지원 URL 확정 전까지 빈 값 — 확정되면 값만 채우면 행이 노출된다.
-const SUPPORT_URL = "";
+const TERMS_URL = "https://eum-dating.com/terms";
+const PRIVACY_URL = "https://eum-dating.com/privacy";
+const SUPPORT_URL = "https://eum-dating.com/support";
 
 export default function MyTabScreen() {
   const router = useRouter();
@@ -339,32 +340,24 @@ export default function MyTabScreen() {
           {/* Apple 심사: 로그인 이후에도 약관/개인정보처리방침 접근이 가능해야 한다 */}
           <TouchableOpacity
             activeOpacity={0.7}
-            onPress={() =>
-              router.push("/onboarding/terms-detail?type=service" as any)
-            }
+            onPress={() => Linking.openURL(TERMS_URL)}
           >
-            <Text style={styles.policyLinkText}>서비스이용약관</Text>
+            <Text style={styles.policyLinkText}>서비스 이용약관</Text>
           </TouchableOpacity>
           <View style={styles.thinDivider} />
           <TouchableOpacity
             activeOpacity={0.7}
-            onPress={() =>
-              router.push("/onboarding/terms-detail?type=privacy" as any)
-            }
+            onPress={() => Linking.openURL(PRIVACY_URL)}
           >
             <Text style={styles.policyLinkText}>개인정보처리방침</Text>
           </TouchableOpacity>
-          {SUPPORT_URL ? (
-            <>
-              <View style={styles.thinDivider} />
-              <TouchableOpacity
-                activeOpacity={0.7}
-                onPress={() => Linking.openURL(SUPPORT_URL)}
-              >
-                <Text style={styles.policyLinkText}>고객지원</Text>
-              </TouchableOpacity>
-            </>
-          ) : null}
+          <View style={styles.thinDivider} />
+          <TouchableOpacity
+            activeOpacity={0.7}
+            onPress={() => Linking.openURL(SUPPORT_URL)}
+          >
+            <Text style={styles.policyLinkText}>고객지원</Text>
+          </TouchableOpacity>
           <View style={styles.thinDivider} />
           <TouchableOpacity
             activeOpacity={0.7}

--- a/app/club/manage-settings.tsx
+++ b/app/club/manage-settings.tsx
@@ -15,6 +15,7 @@ import {
 } from "react-native";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { getApiErrorMessage } from "@/api/axiosInstance";
 import DeleteClubModal from "@/components/club/DeleteClubModal";
 import { CLUB_CREATE_CATEGORIES } from "@/constants/club";
 import { useClubDetailQuery } from "@/hooks/api/useClub";
@@ -106,8 +107,11 @@ export default function ClubManageSettingsScreen() {
           Alert.alert("저장 완료", "동호회 정보가 저장되었어요.");
           router.back();
         },
-        onError: () => {
-          Alert.alert("저장 실패", "잠시 후 다시 시도해주세요.");
+        onError: (error) => {
+          Alert.alert(
+            "저장 실패",
+            getApiErrorMessage(error) ?? "잠시 후 다시 시도해주세요.",
+          );
         },
       },
     );

--- a/app/club/post-create.tsx
+++ b/app/club/post-create.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/club/ClubPostParts";
 import { KEYBOARD_AVOIDING_BEHAVIOR } from "@/constants/keyboard";
 import { createArticle, updateArticle } from "@/api/articles/articlesApi";
+import { getApiErrorMessage } from "@/api/axiosInstance";
 import { getClubPostDetail } from "@/api/clubs/clubPostsApi";
 import { postPresign } from "@/api/onboarding/onboardingApi";
 import {
@@ -152,11 +153,12 @@ export default function ClubPostCreateScreen() {
     },
     onError: (error) => {
       const message =
-        error instanceof Error
+        getApiErrorMessage(error) ??
+        (error instanceof Error
           ? error.message
           : isEditMode
             ? "게시글 수정 중 문제가 발생했습니다."
-            : "게시글 등록 중 문제가 발생했습니다.";
+            : "게시글 등록 중 문제가 발생했습니다.");
       Alert.alert(isEditMode ? "수정 실패" : "등록 실패", message);
     },
   });

--- a/app/club/post-detail.tsx
+++ b/app/club/post-detail.tsx
@@ -36,6 +36,7 @@ import {
   CLUB_COLORS,
 } from "@/components/club/ClubPostParts";
 import { KEYBOARD_AVOIDING_BEHAVIOR } from "@/constants/keyboard";
+import { getApiErrorMessage } from "@/api/axiosInstance";
 import {
   createClubPostComment,
   deleteClubPostComment,
@@ -212,7 +213,8 @@ export default function ClubPostDetailScreen() {
         "댓글 등록 실패",
         getApiErrorStatus(error) === 403
           ? "클럽 회원만 이용할 수 있는 기능이에요"
-          : "댓글을 등록하는 중 문제가 발생했습니다.",
+          : getApiErrorMessage(error) ??
+              "댓글을 등록하는 중 문제가 발생했습니다.",
       );
     },
   });

--- a/app/profile/edit.tsx
+++ b/app/profile/edit.tsx
@@ -23,6 +23,7 @@ import {
 } from "react-native-safe-area-context";
 
 import { postPresign, uploadFileToS3 } from "@/api/onboarding/onboardingApi";
+import { getApiErrorMessage } from "@/api/axiosInstance";
 import CircleImageCropper, {
   CircleCropAsset,
   CircleCropResult,
@@ -223,7 +224,10 @@ export default function ProfileEditScreen() {
       if (__DEV__) {
         console.log("Profile edit submit error:", error);
       }
-      Alert.alert("저장 실패", "프로필을 다시 저장해주세요.");
+      Alert.alert(
+        "저장 실패",
+        getApiErrorMessage(error) ?? "프로필을 다시 저장해주세요.",
+      );
     }
   };
 

--- a/hooks/useNotificationBellBadge.ts
+++ b/hooks/useNotificationBellBadge.ts
@@ -10,22 +10,17 @@ export function useNotificationBellBadge() {
   const enabled = isAuthInitialized && isAuthenticated;
   const heartQuery = useNotificationsInfiniteQuery("heart", undefined, enabled);
   const clubQuery = useNotificationsInfiniteQuery("club", undefined, enabled);
-  const chatQuery = useNotificationsInfiniteQuery("chat", undefined, enabled);
 
   const refetchNotificationBadge = () =>
-    Promise.all([
-      heartQuery.refetch(),
-      clubQuery.refetch(),
-      chatQuery.refetch(),
-    ]);
+    Promise.all([heartQuery.refetch(), clubQuery.refetch()]);
 
   const hasNotificationBadge = useMemo(
     () =>
       enabled &&
-      [heartQuery.data, clubQuery.data, chatQuery.data].some((data) =>
+      [heartQuery.data, clubQuery.data].some((data) =>
         data?.pages.some((page) => page.items.some(isUnreadNotification)),
       ),
-    [enabled, heartQuery.data, clubQuery.data, chatQuery.data],
+    [enabled, heartQuery.data, clubQuery.data],
   );
 
   return {


### PR DESCRIPTION
## 변경 사항

- 백엔드가 반환하는 UGC 필터링 오류 메시지를 프로필, 게시글, 댓글, 동호회 설정 화면에 표시합니다.
- reload 직후 하단 내비게이션 터치가 막히지 않도록 탭바 포인터 이벤트와 레이어 순서를 조정합니다.
- 알림 화면에 표시되지 않는 채팅 알림을 우상단 알림 뱃지 집계에서 제외합니다.
- 마이페이지의 서비스 이용약관, 개인정보처리방침, 고객지원 버튼을 eum-dating.com의 해당 페이지로 연결합니다.

## 원인 및 영향

- API 실패 시 화면별 고정 문구만 사용해 서버의 구체적인 필터링 사유가 가려졌습니다.
- 커스텀 탭바 래퍼가 reload 이후 터치 이벤트를 가로챌 수 있었습니다.
- 알림 뱃지에서 채팅 미읽음 상태까지 합산하지만 알림 화면에는 채팅 알림이 없어 빈 알림과 빨간 점이 함께 보였습니다.
- 마이페이지 약관은 앱 내부 화면으로 이동했고 고객지원 주소는 비어 있어 노출되지 않았습니다.

## 검증

- `CI=true pnpm exec tsc --noEmit`
- 변경된 8개 파일 ESLint: 오류 0개 (기존 Hook 의존성 경고 2개)
- `git diff --check origin/dev...HEAD`
- reload 후 내비게이션 터치 및 알림 뱃지 동작 수동 확인
- 웹사이트 `/terms`, `/privacy`, `/support` HTTP 200 확인

Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 서버에서 제공하는 구체적인 오류 메시지가 저장, 게시글 작성·수정, 댓글 등록, 프로필 편집 실패 시 안내에 표시됩니다.
  - 약관, 개인정보처리방침, 고객지원 메뉴가 외부 페이지로 열립니다.
  - 고객지원 메뉴가 항상 표시됩니다.
  - 알림 배지는 하트 및 클럽 알림을 기준으로 표시되도록 변경되었습니다.

- **버그 수정**
  - 탭바 주변의 터치 동작과 화면 레이어 표시를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->