### PR TITLE
fix: 동호회 최신화 및 추천 카드 정보 보완

### DIFF
--- a/api/axiosInstance.ts
+++ b/api/axiosInstance.ts
@@ -37,6 +37,7 @@ const api = create({
   baseURL: normalizedBaseUrl,
   headers: { "Content-Type": "application/json" },
   withCredentials: true,
+  timeout: 15000,
 });
 
 const formatDebugPayload = (payload: unknown) => {

--- a/api/club/clubApi.ts
+++ b/api/club/clubApi.ts
@@ -104,7 +104,7 @@ export const getTodayRecommendedClubs = async (
   params: { limit?: number } = {},
 ) => {
   const { data } = await api.get<
-    ApiSuccessResponse<DTO.IRecommendedClubsResponse>
+    ApiSuccessResponse<DTO.ITodayRecommendedClubsResponse>
   >("/v1/clubs/today-recommended", { params });
   return data.success.data;
 };

--- a/app/club/detail.tsx
+++ b/app/club/detail.tsx
@@ -2,9 +2,9 @@ import { Ionicons } from "@expo/vector-icons";
 import { Image } from "@/components/Image";
 import { KeyboardAvoidingView } from "@/components/KeyboardCompat";
 import { useQueryClient } from "@tanstack/react-query";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -169,11 +169,30 @@ export default function ClubDetailScreen() {
     myClubsQuery.data?.items.find((item) => Number(item.clubId) === clubId)
       ?.status ?? null;
   // 이 화면에서 방금 바꾼 로컬 상태가 서버 목록 캐시보다 우선한다.
-  const effectiveJoinStatus = joinStatus ?? myClubStatus;
+  // 단 로컬 PENDING은 예외 — 승인/거절은 서버에서 일어나므로 갱신된 서버 상태가 이긴다.
+  // (이게 없으면 refetch로 ACTIVE를 받아와도 화면은 계속 "가입 대기중"으로 남는다.)
+  const effectiveJoinStatus =
+    joinStatus === "PENDING" && myClubStatus && myClubStatus !== "PENDING"
+      ? myClubStatus
+      : (joinStatus ?? myClubStatus);
   const isJoined =
     effectiveJoinStatus === "ACTIVE" ||
     Boolean(detail?.isJoined && joinStatus !== "LEFT");
   const isJoinPending = effectiveJoinStatus === "PENDING";
+
+  // 승인은 호스트 기기에서 일어나므로 이 기기 캐시가 갱신되지 않는다.
+  // 전역 staleTime이 1시간이라 PENDING 캐시를 계속 쓰게 되므로,
+  // 가입 대기 중일 때만 화면 진입/재포커스 시 내 동호회 목록과 상세를 다시 불러온다.
+  const refetchMyClubs = myClubsQuery.refetch;
+  const refetchDetail = detailQuery.refetch;
+  useFocusEffect(
+    useCallback(() => {
+      if (!isJoinPending) return;
+      refetchMyClubs();
+      refetchDetail();
+    }, [isJoinPending, refetchMyClubs, refetchDetail]),
+  );
+
   const isHost = detail?.myAuthority === "HOST";
   // 게스트/멤버/호스트 역할과 화면 권한을 한 곳에서 계산한다.
   const viewer = getClubViewer({ isJoined, isHost });
@@ -2452,6 +2471,8 @@ const styles = StyleSheet.create({
   meetingSheetDivider: {
     height: 1,
     backgroundColor: "#DEE3E5",
+    // 구분선과 "안내사항" 제목이 붙어 보여서 아래쪽 여백을 준다.
+    marginBottom: 24,
   },
   meetingSheetBar: {
     alignSelf: "stretch",

--- a/app/club/post-detail.tsx
+++ b/app/club/post-detail.tsx
@@ -113,6 +113,11 @@ export default function ClubPostDetailScreen() {
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     enabled: hasPostId,
+    // 다른 사용자의 새 댓글은 이 기기 캐시를 invalidate하지 못하므로,
+    // 이 화면이 열려 있는 동안에만 짧게 폴링한다(전역 staleTime 1시간은 그대로 둔다).
+    staleTime: 0,
+    refetchInterval: 20_000,
+    refetchOnWindowFocus: true,
   });
   const likeMutation = useMutation({
     mutationFn: (nextLiked: boolean) =>

--- a/components/club/ClubPostParts.tsx
+++ b/components/club/ClubPostParts.tsx
@@ -519,7 +519,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 18,
     paddingHorizontal: 20,
+    // 본문 입력 영역과 사진 미리보기를 구분한다. 구분선은 아래 mediaBar와 동일한 톤을 쓴다.
+    borderTopWidth: 1,
+    borderTopColor: CLUB_COLORS.gray300,
     paddingTop: 18,
+    paddingBottom: 14,
   },
   previewItem: {
     width: 82,

--- a/components/home/HomeScreen.tsx
+++ b/components/home/HomeScreen.tsx
@@ -866,6 +866,7 @@ type ClubRowSource = {
   sidoCode?: string | null;
   sigunguCode?: string | null;
   district?: string | null;
+  memberCount?: number | null;
 };
 
 type ClubRowsData = {
@@ -891,6 +892,10 @@ function mapClubRows(
           club.addressName?.trim() ||
           club.district?.trim() ||
           undefined,
+        // 응답에 memberCount가 없으면 "N명 참석중"을 숨긴다(임의 값 만들지 않음).
+        // today-recommended는 memberCount를 내려주지만 위치 필드가 없어 district가 항상 비어 있다.
+        // ponytail: 백엔드가 addressName을 추가하면 위 매핑이 그대로 동작한다.
+        members: club.memberCount ?? undefined,
         thumbnailUrl: club.thumbnailUrl,
       })),
     (item) => item.id,

--- a/hooks/api/useArticles.ts
+++ b/hooks/api/useArticles.ts
@@ -43,6 +43,11 @@ export function useArticlesInfiniteQuery(
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     enabled: enabled && Number.isFinite(clubId),
+    // 다른 사용자의 새 게시물은 이 기기 캐시를 invalidate하지 못하므로,
+    // 게시판 탭이 열려 있는 동안에만 짧게 폴링한다(전역 staleTime 1시간은 그대로 둔다).
+    staleTime: 0,
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/types/api/club/clubDTO.ts
+++ b/types/api/club/clubDTO.ts
@@ -207,6 +207,9 @@ export interface IRecommendedClubItem {
   capacity: number;
   likes: number;
   similarityScore: number;
+  // 미검증(401로 실응답 확인 못 함). 현재 이 엔드포인트는 참석 인원을 안 내려주는 것으로 보이며,
+  // 백엔드가 추가하면 홈 "나를 위한 동호회" 카드의 "N명 참석중"이 바로 표시된다.
+  memberCount?: number;
 }
 
 export interface IRecommendedClubsResponse {
@@ -216,6 +219,32 @@ export interface IRecommendedClubsResponse {
     hasNext: boolean;
     nextCursor?: string | null;
   };
+}
+
+// v1/clubs/today-recommended (GET)
+// 2026-07-20 실제 응답 확인 결과 /v1/matches/club/recommended와 shape이 다르다.
+// 위치 필드(addressName/areaName/addressCode/sidoCode/sigunguCode)가 아예 없어서
+// 홈 "오늘의 추천 동호회" 카드에 지역이 표시되지 않는다 — 백엔드 추가 필요.
+export interface ITodayRecommendedClubItem {
+  clubId: string;
+  name: string;
+  category: ClubCategory;
+  introText: string | null;
+  thumbnailUrl: string | null;
+  capacity: number;
+  memberCount: number;
+  likes: number;
+  recommendationScore: number;
+  // 이 응답은 userId/clubId를 문자열로 내려줘서 IClubUserSummary(userId: number)와 다르다.
+  host: {
+    userId: number | string;
+    nickname: string;
+    profileImageUrl: string | null;
+  };
+}
+
+export interface ITodayRecommendedClubsResponse {
+  items: ITodayRecommendedClubItem[];
 }
 
 // v1/clubs/search/recent (GET)


### PR DESCRIPTION
## 변경 사항

- 가입 대기 상태에서 동호회 상세 재진입 시 승인 결과를 다시 조회합니다.
- 게시판과 게시글 상세에서 다른 사용자의 새 게시물·댓글을 짧은 주기로 반영합니다.
- 추천 동호회 카드에 API가 제공하는 참석 인원을 표시합니다.
- 게시글 사진 미리보기와 본문을 구분하고, 정기모임 안내사항 위 여백을 추가합니다.
- Axios 전역 요청 timeout을 15초로 설정합니다.

## 원인

전역 React Query stale time이 1시간이라 다른 사용자가 만든 승인·게시물·댓글 변경이 현재 기기에 반영되지 않았습니다. 추천 응답의 참석 인원도 카드 매핑에서 누락돼 있었습니다.

## 검증

- `pnpm exec tsc --noEmit`
- iOS Expo bundle export
- `git diff --check`

## 참고

오늘의 추천 API는 위치 필드를 내려주지 않아 위치 표시는 백엔드 응답 추가가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 네트워크 요청 시간이 15초를 초과하면 자동으로 종료됩니다.
  - 오늘의 추천 모임 정보와 모임 인원 표시가 응답 데이터에 맞게 개선되었습니다.
  - 가입 대기 중인 모임은 화면 재진입 시 최신 가입 상태를 자동으로 반영합니다.
  - 게시글과 댓글이 각각 30초, 20초 간격으로 갱신되며 화면 포커스 전환 시에도 업데이트됩니다.

- **UI 개선**
  - 댓글·사진 미리보기 영역의 구분선과 여백이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->