### PR TITLE
fix: 사용자별 추천 캐시 격리 및 프로필 변경 반영

### DIFF
--- a/hooks/api/queryKeys.ts
+++ b/hooks/api/queryKeys.ts
@@ -14,7 +14,8 @@ export const queryKeys = {
   },
   recommendations: {
     all: ["recommendations"] as const,
-    list: (size: number) => [...queryKeys.recommendations.all, { size }] as const,
+    list: (userId: number, size: number) =>
+      [...queryKeys.recommendations.all, { userId, size }] as const,
   },
   socials: {
     all: ["socials"] as const,

--- a/hooks/api/useOnboarding.ts
+++ b/hooks/api/useOnboarding.ts
@@ -35,6 +35,7 @@ export function usePostProfileMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
       queryClient.invalidateQueries({ queryKey: queryKeys.onboarding.profile() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recommendations.all });
     },
   });
 }
@@ -56,6 +57,7 @@ export function usePutOnboardingIdealPersonalitiesMutation() {
         queryKey: queryKeys.onboarding.idealPersonalities(),
       });
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recommendations.all });
     },
   });
 }

--- a/hooks/api/useRecommendations.ts
+++ b/hooks/api/useRecommendations.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-q
 
 import { getRecommendations } from "@/api/onboarding/onboardingApi";
 import { sendHeart } from "@/api/socials/socialsApi";
+import { useAuthStore } from "@/stores/authStore";
 
 import { queryKeys } from "./queryKeys";
 import { useProtectedQueryEnabled } from "./useProtectedQueryEnabled";
@@ -12,10 +13,11 @@ export function useRecommendationsInfiniteQuery(
   size = DEFAULT_RECOMMENDATION_SIZE,
   enabled = true,
 ) {
-  const queryEnabled = useProtectedQueryEnabled(enabled);
+  const userId = useAuthStore((state) => state.user?.userId);
+  const queryEnabled = useProtectedQueryEnabled(enabled && !!userId);
 
   return useInfiniteQuery({
-    queryKey: queryKeys.recommendations.list(size),
+    queryKey: queryKeys.recommendations.list(userId ?? 0, size),
     queryFn: ({ pageParam }) =>
       getRecommendations({
         cursor: pageParam ?? undefined,

--- a/hooks/api/useUsers.ts
+++ b/hooks/api/useUsers.ts
@@ -119,6 +119,7 @@ export function useUpdateMyProfileMutation() {
     mutationFn: (body: IPatchUserProfileRequest) => updateMyProfile(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recommendations.all });
     },
   });
 }
@@ -148,6 +149,7 @@ export function usePutInterestKeywordsMutation() {
     mutationFn: (body: IKeywordsRequest) => putInterestKeywords(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recommendations.all });
     },
   });
 }
@@ -159,6 +161,7 @@ export function usePutPersonalitiesMutation() {
     mutationFn: (body: IKeywordsRequest) => putPersonalities(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recommendations.all });
     },
   });
 }
@@ -170,6 +173,7 @@ export function usePutIdealPersonalitiesMutation() {
     mutationFn: (body: IPutIdealRequest) => putIdealPersonalities(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recommendations.all });
     },
   });
 }

--- a/hooks/usePrefetchAppData.ts
+++ b/hooks/usePrefetchAppData.ts
@@ -53,10 +53,13 @@ const MAX_PREFETCH_CLUB_DETAILS = 8;
 export function usePrefetchAppData(queryClient: QueryClient) {
   const isAuthInitialized = useAuthStore((state) => state.isAuthInitialized);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const ready = isAuthInitialized && isAuthenticated;
+  const onboardingRequired = useAuthStore((state) => state.onboardingRequired);
+  const userId = useAuthStore((state) => state.user?.userId);
+  const ready =
+    isAuthInitialized && isAuthenticated && !onboardingRequired && !!userId;
 
   useEffect(() => {
-    if (!ready) return;
+    if (!ready || !userId) return;
 
     const prefetchInfinite = <TPage,>(
       queryKey: readonly unknown[],
@@ -73,7 +76,7 @@ export function usePrefetchAppData(queryClient: QueryClient) {
       const clubDetailIds = new Set<number>();
       const tasks: Promise<unknown>[] = [
         // 홈
-        prefetchInfinite(queryKeys.recommendations.list(10), (cursor) =>
+        prefetchInfinite(queryKeys.recommendations.list(userId, 10), (cursor) =>
           getRecommendations({ cursor: cursor ?? undefined, size: 10 }),
         ),
         queryClient.prefetchQuery({
@@ -156,5 +159,5 @@ export function usePrefetchAppData(queryClient: QueryClient) {
     };
 
     void run();
-  }, [ready, queryClient]);
+  }, [ready, queryClient, userId]);
 }


### PR DESCRIPTION
## 변경 사항

- 추천 React Query key에 현재 `userId`를 포함해 계정별 캐시를 격리했습니다.
- 사용자 ID가 확정되기 전에는 추천 query를 실행하지 않도록 했습니다.
- 앱 데이터 프리패치를 사용자 ID가 존재하고 온보딩이 완료된 뒤에만 실행하도록 변경했습니다.
- 프로필, 관심사, 성격, 이상형 및 온보딩 정보 저장 성공 시 추천 캐시를 무효화하도록 했습니다.

## 배경

추천 API 응답은 로그인 사용자 기준으로 달라지지만 기존 query key는 `size`만 사용했습니다. 또한 추천 기준이 되는 프로필을 변경해도 추천 캐시가 무효화되지 않아, 최대 1시간 동안 이전 사용자 또는 변경 전 기준의 추천이 표시될 수 있었습니다.

## 사용자 영향

- 계정 전환 시 다른 사용자의 추천 캐시가 재사용되지 않습니다.
- 온보딩 및 추천 기준 프로필 변경 후 최신 기준으로 추천을 다시 조회합니다.
- 온보딩 도중 생성된 추천 캐시가 완료 후 재사용되지 않습니다.

## 검증

- `pnpm lint` 통과 (기존 경고 4개, 오류 0개)
- `CI=true pnpm exec tsc --noEmit` 통과
- `git diff --check` 통과

Closes #228
Closes #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 추천 콘텐츠가 사용자별로 구분되어 더욱 정확하게 제공됩니다.
  * 로그인과 온보딩이 완료된 후 추천 데이터가 미리 로드되어 화면 전환이 빨라집니다.
  * 프로필, 관심사, 성격 정보를 변경하면 추천 콘텐츠가 자동으로 최신 상태로 갱신됩니다.
  * 로그인 정보나 사용자 식별 정보가 준비되지 않은 상태에서는 불필요한 추천 데이터 요청이 발생하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->