### PR TITLE
[EUM-232] fix: 이상형 추천 카운트다운 기준 시각 수정

### DIFF
--- a/components/home/HomeScreen.tsx
+++ b/components/home/HomeScreen.tsx
@@ -217,6 +217,15 @@ export default function HomePage() {
     fabAnimation.setValue(1);
   }, [fabAnimation, tabPressAt]);
 
+  // 캐시 복원 후에도 마지막 추천 갱신 시각을 기준으로 남은 시간을 표시합니다.
+  useEffect(() => {
+    if (!recommendationsQuery.dataUpdatedAt) return;
+
+    countdownEndAt.current =
+      recommendationsQuery.dataUpdatedAt + RECOMMENDATION_COUNTDOWN_MS;
+    setCountdown(getCountdownText(countdownEndAt.current));
+  }, [recommendationsQuery.dataUpdatedAt]);
+
   // 추천 마감 카운트다운이 끝나면 추천 목록을 새로 받아옵니다.
   useEffect(() => {
     const tick = () => {

--- a/components/home/HomeScreen.tsx
+++ b/components/home/HomeScreen.tsx
@@ -231,8 +231,11 @@ export default function HomePage() {
     const tick = () => {
       const now = Date.now();
 
-      if (now >= countdownEndAt.current) {
-        countdownEndAt.current = now + RECOMMENDATION_COUNTDOWN_MS;
+      if (
+        now >= countdownEndAt.current &&
+        !recommendationsQuery.isFetching &&
+        !recommendationsQuery.isError
+      ) {
         setProfileIndex(0);
         profileListRef.current?.scrollToOffset({ offset: 0, animated: false });
         void refetchRecommendations();
@@ -244,7 +247,11 @@ export default function HomePage() {
     tick();
     const timer = setInterval(tick, 1000);
     return () => clearInterval(timer);
-  }, [refetchRecommendations]);
+  }, [
+    recommendationsQuery.isError,
+    recommendationsQuery.isFetching,
+    refetchRecommendations,
+  ]);
 
   // 추천 목록 길이가 변해도 현재 인덱스가 유효한 카드만 가리키도록 보정합니다.
   useEffect(() => {


### PR DESCRIPTION
## 변경 사항

- 이상형 추천 카운트다운 만료 시각을 `HomeScreen` 마운트 시각이 아닌 추천 쿼리의 `dataUpdatedAt` 기준으로 계산합니다.
- 캐시 복원 및 추천 refetch 성공 후 갱신된 시각을 기존 카운트다운 ref에 동기화합니다.

## 배경

기존에는 앱 재실행이나 화면 재마운트 시 카운트다운이 다시 1시간으로 초기화되어, 캐시된 추천 데이터의 실제 갱신 시각과 화면의 남은 시간이 불일치할 수 있었습니다.

## 사용자 영향

앱 재실행 및 캐시 복원 후에도 마지막 추천 조회 성공 시각을 기준으로 정확한 남은 시간이 표시됩니다. 기존 만료 refetch, 카드 초기화, 페이지네이션 및 하트 전송 후 추천 갱신 동작은 유지됩니다.

## 검증

- `pnpm exec eslint components/home/HomeScreen.tsx`
- `CI=true pnpm exec tsc --noEmit`
- `git diff --check`

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 추천 데이터가 새로고침되거나 캐시에서 복원된 후에도 추천 카운트다운이 최신 업데이트 시점을 기준으로 정확하게 표시되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->