### PR TITLE
fix: iPad 호환 모드 온보딩 화면 잘림 수정

### DIFF
--- a/app/onboarding/login.tsx
+++ b/app/onboarding/login.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react";
 import {
   Image,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   useWindowDimensions,
@@ -47,8 +48,11 @@ export default function LoginScreen() {
 
   // Figma 기준 프레임(412x892)을 작은 화면에서도 자연스럽게 줄여 적용한다.
   const layoutScale = Math.min(width / 412, height / 892, 1);
+  const isCompactHeight = height < 750;
   const illustrationWidth = 280 * layoutScale;
   const illustrationHeight = 326 * layoutScale;
+  const illustrationMarginTop =
+    (isCompactHeight ? 80 : 221) * layoutScale;
   const bottomMarginTop = (isAppleAuthAvailable ? 48 : 112) * layoutScale;
 
   // 이용약관 확인 후 → 앱 접근 권한 안내로 이동
@@ -58,10 +62,18 @@ export default function LoginScreen() {
   };
 
   return (
-    <View style={[styles.container, { paddingBottom: insets.bottom + 24 }]}>
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={[
+        styles.contentContainer,
+        { paddingBottom: insets.bottom + 24 },
+      ]}
+      showsVerticalScrollIndicator={false}
+      bounces={false}
+    >
       {/* 상단: 일러스트 영역 */}
       <View
-        style={[styles.illustrationArea, { marginTop: 221 * layoutScale }]}
+        style={[styles.illustrationArea, { marginTop: illustrationMarginTop }]}
       >
         {/* Figma에서 추출한 온보딩 일러스트 */}
         <Image
@@ -149,7 +161,7 @@ export default function LoginScreen() {
         onConfirm={handleTermsConfirm}
         onClose={() => setShowTermsSheet(false)}
       />
-    </View>
+    </ScrollView>
   );
 }
 
@@ -157,6 +169,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "#FFFFFF",
+  },
+  contentContainer: {
+    flexGrow: 1,
   },
   // 상단 일러스트 영역
   illustrationArea: {

--- a/components/profile/ProfileVoiceParts.tsx
+++ b/components/profile/ProfileVoiceParts.tsx
@@ -210,14 +210,25 @@ export function PlaybackControls({
 }
 
 export function AnalyzingView({ userName }: { userName: string }) {
+  const { height } = useWindowDimensions();
+  const isCompactHeight = height < 750;
+
   return (
-    <View style={styles.analyzingWrap}>
+    <ScrollView
+      style={styles.analyzingScroll}
+      contentContainerStyle={[
+        styles.analyzingWrap,
+        isCompactHeight && styles.analyzingWrapCompact,
+      ]}
+      showsVerticalScrollIndicator={false}
+      bounces={false}
+    >
       <AnalyzingMark />
       <Text style={styles.analyzingTitle}>잠시만 기다려주세요...</Text>
       <Text style={styles.analyzingSubtitle}>
         AI가 {userName}님의 이야기를 정리중이에요!
       </Text>
-      <View style={styles.tipBox}>
+      <View style={[styles.tipBox, isCompactHeight && styles.tipBoxCompact]}>
         <View style={styles.tipBadge}>
           <Text style={styles.tipBadgeText}>Tip</Text>
         </View>
@@ -226,7 +237,7 @@ export function AnalyzingView({ userName }: { userName: string }) {
           아시나요?
         </Text>
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
@@ -377,7 +388,7 @@ export function CompletePreviewView({
       ? profileImageUri
       : DEFAULT_PROFILE_IMAGE_URI;
   const { height } = useWindowDimensions();
-  const previewCardHeight = Math.min(472, Math.max(390, height - 420));
+  const previewCardHeight = Math.min(472, Math.max(260, height - 420));
 
   return (
     <View style={styles.completeScreen}>
@@ -748,11 +759,18 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  analyzingWrap: {
+  analyzingScroll: {
     flex: 1,
+  },
+  analyzingWrap: {
+    flexGrow: 1,
     alignItems: "center",
     paddingTop: 133,
     paddingHorizontal: 20,
+    paddingBottom: 24,
+  },
+  analyzingWrapCompact: {
+    paddingTop: 48,
   },
   analyzingMark: {
     width: 126,
@@ -805,10 +823,8 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   tipBox: {
-    position: "absolute",
-    left: 20,
-    right: 20,
-    top: 503,
+    width: "100%",
+    marginTop: 112,
     minHeight: 98,
     borderRadius: 14,
     borderWidth: 1,
@@ -822,6 +838,9 @@ const styles = StyleSheet.create({
     shadowRadius: 18,
     shadowOffset: { width: 0, height: 4 },
     elevation: 5,
+  },
+  tipBoxCompact: {
+    marginTop: 48,
   },
   tipBadge: {
     paddingHorizontal: 10,


### PR DESCRIPTION
Closes #236

## 변경 사항
- 짧은 화면에서 로그인 화면을 스크롤할 수 있도록 하고 상단 여백을 축소했습니다.
- 음성 분석 중 Tip 영역의 절대 위치를 제거해 화면 높이에 맞게 자연스럽게 배치했습니다.
- 프로필 완료 미리보기 카드의 최소 높이를 줄여 하단 CTA가 잘리지 않도록 했습니다.

## 원인
iPad의 iPhone 호환 모드(약 375×667)에서 고정 여백, 절대 위치, 큰 최소 높이가 함께 적용되어 하단 콘텐츠가 화면 밖으로 잘렸습니다.

## 검증
- iPhone SE 3세대 시뮬레이터(375×667)에서 로그인/분석 중/완료 화면 육안 확인
- `pnpm exec eslint app/onboarding/login.tsx components/profile/ProfileVoiceParts.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm expo export --platform ios --output-dir /private/tmp/eum-export-responsive --clear`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 로그인 화면이 다양한 화면 높이에 맞게 조정되어 작은 화면에서도 콘텐츠를 더 편하게 확인할 수 있습니다.
  * 분석 화면에 스크롤이 지원되며, 화면 크기에 따라 여백과 미리보기 카드 크기가 최적화되었습니다.
  * 분석 팁이 콘텐츠 흐름에 맞게 표시되어 화면 겹침이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->