### PR TITLE
fix: iPad 호환 모드 UI 잘림 수정

### DIFF
--- a/app/onboarding/permissions.tsx
+++ b/app/onboarding/permissions.tsx
@@ -6,7 +6,7 @@ import {
 import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
 import React, { useEffect, useMemo, useState } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useAuthStore } from "@/stores/authStore";
@@ -147,7 +147,12 @@ export default function PermissionsScreen() {
       </View>
 
       {/* 권한 카드 목록 */}
-      <View style={styles.cardList}>
+      <ScrollView
+        style={styles.cardListScroll}
+        contentContainerStyle={styles.cardList}
+        showsVerticalScrollIndicator={false}
+        bounces={false}
+      >
         {PERMISSIONS.map((item) => {
           const permissionState = permissions[item.id];
           const isActive = permissionState === "granted";
@@ -172,7 +177,7 @@ export default function PermissionsScreen() {
             </View>
           );
         })}
-      </View>
+      </ScrollView>
 
       {/* 하단 영역 */}
       <View style={styles.bottomArea}>
@@ -235,8 +240,11 @@ const styles = StyleSheet.create({
     lineHeight: 23,
     textAlign: "center",
   },
-  cardList: {
+  cardListScroll: {
     flex: 1,
+  },
+  cardList: {
+    flexGrow: 1,
     paddingHorizontal: 20,
     gap: 12,
   },

--- a/app/profile/age.tsx
+++ b/app/profile/age.tsx
@@ -6,6 +6,7 @@ import {
   NativeSyntheticEvent,
   ScrollView,
   StyleSheet,
+  useWindowDimensions,
   View,
 } from "react-native";
 
@@ -17,8 +18,9 @@ const MAX_AGE = 120;
 const DEFAULT_AGE = 60;
 const ITEM_HEIGHT = 58;
 const VISIBLE_ITEMS = 7;
-const PICKER_HEIGHT = ITEM_HEIGHT * VISIBLE_ITEMS;
-const PICKER_PADDING = (PICKER_HEIGHT - ITEM_HEIGHT) / 2;
+// ponytail: 작은 높이(iPad 호환 모드 등)에서는 보이는 항목 수만 줄인다.
+// 스냅·오프셋 계산은 ITEM_HEIGHT만 쓰므로 영향받지 않는다.
+const COMPACT_VISIBLE_ITEMS = 5;
 const SELECTION_OFFSET = 24;
 
 /**
@@ -28,6 +30,10 @@ const SELECTION_OFFSET = 24;
  */
 export default function AgeScreen() {
   const router = useRouter();
+  const { height } = useWindowDimensions();
+  const visibleItems = height < 750 ? COMPACT_VISIBLE_ITEMS : VISIBLE_ITEMS;
+  const pickerHeight = ITEM_HEIGHT * visibleItems;
+  const pickerPadding = (pickerHeight - ITEM_HEIGHT) / 2;
   const draftAge = useOnboardingDraftStore((state) => state.age);
   const setDraftAge = useOnboardingDraftStore((state) => state.setAge);
   const initialAge = clampAge(draftAge ?? DEFAULT_AGE);
@@ -85,8 +91,11 @@ export default function AgeScreen() {
       <View style={styles.pickerContainer}>
         <Animated.ScrollView
           ref={scrollRef}
-          style={styles.pickerWindow}
-          contentContainerStyle={styles.pickerContent}
+          style={[styles.pickerWindow, { height: pickerHeight }]}
+          contentContainerStyle={{
+            paddingTop: pickerPadding + SELECTION_OFFSET,
+            paddingBottom: pickerPadding + SELECTION_OFFSET + ITEM_HEIGHT,
+          }}
           showsVerticalScrollIndicator={false}
           snapToInterval={ITEM_HEIGHT}
           decelerationRate="fast"
@@ -167,12 +176,7 @@ const styles = StyleSheet.create({
     overflow: "hidden",
   },
   pickerWindow: {
-    height: PICKER_HEIGHT,
     width: 160,
-  },
-  pickerContent: {
-    paddingTop: PICKER_PADDING + SELECTION_OFFSET,
-    paddingBottom: PICKER_PADDING + SELECTION_OFFSET + ITEM_HEIGHT,
   },
   pickerItem: {
     height: ITEM_HEIGHT,

--- a/app/profile/gender.tsx
+++ b/app/profile/gender.tsx
@@ -1,7 +1,13 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import React, { useState } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+} from "react-native";
 
 import ProfileStepLayout from "@/components/profile/ProfileStepLayout";
 import { useOnboardingDraftStore } from "@/stores/onboardingDraftStore";
@@ -26,6 +32,10 @@ const GENDERS: GenderOption[] = [
  */
 export default function GenderScreen() {
   const router = useRouter();
+  // ponytail: 원 2개(150) + gap 48 = 348이라 작은 높이에서 "다음" 버튼을 덮는다.
+  const { height } = useWindowDimensions();
+  const isCompactHeight = height < 750;
+  const circleSize = isCompactHeight ? 116 : 150;
   const draftGender = useOnboardingDraftStore((state) => state.gender);
   const setDraftGender = useOnboardingDraftStore((state) => state.setGender);
   const [selected, setSelected] = useState<Gender>(
@@ -51,7 +61,12 @@ export default function GenderScreen() {
       buttonEnabled={selected !== null}
       onNext={handleNext}
     >
-      <View style={styles.optionsContainer}>
+      <View
+        style={[
+          styles.optionsContainer,
+          isCompactHeight && styles.optionsContainerCompact,
+        ]}
+      >
         {GENDERS.map((gender) => {
           const isActive = selected === gender.id;
           return (
@@ -59,6 +74,11 @@ export default function GenderScreen() {
               key={gender.id}
               style={[
                 styles.genderCircle,
+                {
+                  width: circleSize,
+                  height: circleSize,
+                  borderRadius: circleSize / 2,
+                },
                 isActive && styles.genderCircleActive,
               ]}
               onPress={() => setSelected(gender.id)}
@@ -91,10 +111,10 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 48,
   },
+  optionsContainerCompact: {
+    gap: 20,
+  },
   genderCircle: {
-    width: 150,
-    height: 150,
-    borderRadius: 75,
     borderWidth: 2,
     borderColor: "#DEE3E5",
     backgroundColor: "#F8FAFB",

--- a/app/profile/welcome.tsx
+++ b/app/profile/welcome.tsx
@@ -12,7 +12,7 @@ import type { AudioPlayer } from "expo-audio";
 import { useRouter } from "expo-router";
 import { useQueryClient } from "@tanstack/react-query";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Alert, StyleSheet, View } from "react-native";
+import { Alert, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { postPresign } from "@/api/onboarding/onboardingApi";
@@ -672,36 +672,42 @@ export default function WelcomeScreen() {
   return (
     <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
       <VoiceHeader onBack={handleBack} />
-      <View style={styles.content}>
-        <VoiceTitle>
-          {step === "recording" || step === "reviewing"
-            ? `${userName}님의 이야기를 듣고있어요..`
-            : `반갑습니다! ${userName}님\n${userName}님의 이야기를 들려주세요.`}
-        </VoiceTitle>
-        <VoiceExamples compact={step === "recording" || step === "reviewing"} />
-      </View>
+      <ScrollView
+        contentContainerStyle={styles.voiceScrollContent}
+        showsVerticalScrollIndicator={false}
+        bounces={false}
+      >
+        <View style={styles.content}>
+          <VoiceTitle>
+            {step === "recording" || step === "reviewing"
+              ? `${userName}님의 이야기를 듣고있어요..`
+              : `반갑습니다! ${userName}님\n${userName}님의 이야기를 들려주세요.`}
+          </VoiceTitle>
+          <VoiceExamples compact={step === "recording" || step === "reviewing"} />
+        </View>
 
-      {step === "recording" ? (
-        <RecordingControls
-          seconds={recordingSeconds}
-          showShortWarning={showShortWarning}
-          onCancel={handleCancelRecording}
-          onFinish={handleFinishRecording}
-          onReset={handleResetRecording}
-        />
-      ) : step === "reviewing" ? (
-        <PlaybackControls
-          seconds={recordingSeconds}
-          isPlaying={isPlayingRecorded}
-          isSubmitting={isUploadingAudio}
-          onCancel={handleCancelRecording}
-          onTogglePlay={handleTogglePlayback}
-          onSubmit={handleSubmitRecording}
-          onReset={handleResetRecording}
-        />
-      ) : (
-        <IdleRecorder onStart={handleStartRecording} />
-      )}
+        {step === "recording" ? (
+          <RecordingControls
+            seconds={recordingSeconds}
+            showShortWarning={showShortWarning}
+            onCancel={handleCancelRecording}
+            onFinish={handleFinishRecording}
+            onReset={handleResetRecording}
+          />
+        ) : step === "reviewing" ? (
+          <PlaybackControls
+            seconds={recordingSeconds}
+            isPlaying={isPlayingRecorded}
+            isSubmitting={isUploadingAudio}
+            onCancel={handleCancelRecording}
+            onTogglePlay={handleTogglePlayback}
+            onSubmit={handleSubmitRecording}
+            onReset={handleResetRecording}
+          />
+        ) : (
+          <IdleRecorder onStart={handleStartRecording} />
+        )}
+      </ScrollView>
     </SafeAreaView>
   );
 }
@@ -714,6 +720,10 @@ const styles = StyleSheet.create({
   content: {
     paddingHorizontal: 20,
     paddingTop: 22,
+  },
+  // ponytail: 작은 높이에서만 스크롤되고, 여유가 있으면 녹음 컨트롤이 하단에 붙는다.
+  voiceScrollContent: {
+    flexGrow: 1,
   },
 });
 

--- a/components/profile/ProfileStepLayout.tsx
+++ b/components/profile/ProfileStepLayout.tsx
@@ -1,7 +1,13 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import React from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+} from "react-native";
 import { KeyboardAvoidingView } from "@/components/KeyboardCompat";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { KEYBOARD_AVOIDING_BEHAVIOR } from "@/constants/keyboard";
@@ -55,6 +61,10 @@ const ProfileStepLayout = ({
 }: ProfileStepLayoutProps) => {
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  // ponytail: 고정 chrome이 242pt라 작은 높이 + 키보드에서 하단 버튼이 화면 밖으로 밀린다.
+  // 여백만 줄여 약 46pt를 회수한다.
+  const { height } = useWindowDimensions();
+  const isCompactHeight = height < 750;
 
   return (
     <KeyboardAvoidingView
@@ -79,8 +89,12 @@ const ProfileStepLayout = ({
       />
 
       {/* 제목 + 서브타이틀 */}
-      <View style={styles.titleArea}>
-        <Text style={styles.title}>{title}</Text>
+      <View
+        style={[styles.titleArea, isCompactHeight && styles.titleAreaCompact]}
+      >
+        <Text style={[styles.title, isCompactHeight && styles.titleCompact]}>
+          {title}
+        </Text>
         {subtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
       </View>
 
@@ -88,7 +102,12 @@ const ProfileStepLayout = ({
       <View style={styles.content}>{children}</View>
 
       {!hideBottomButton && (
-        <View style={[styles.bottomArea, { paddingBottom: insets.bottom + 24 }]}>
+        <View
+          style={[
+            styles.bottomArea,
+            { paddingBottom: insets.bottom + (isCompactHeight ? 12 : 24) },
+          ]}
+        >
           <Pressable
             style={({ pressed }) => [
               styles.nextButton,
@@ -141,11 +160,19 @@ const styles = StyleSheet.create({
     paddingBottom: 20,
     gap: 4,
   },
+  titleAreaCompact: {
+    paddingTop: 12,
+    paddingBottom: 10,
+  },
   title: {
     fontSize: 28,
     fontWeight: "600",
     color: "#202020",
     lineHeight: 36,
+  },
+  titleCompact: {
+    fontSize: 24,
+    lineHeight: 30,
   },
   subtitle: {
     fontSize: 14,

--- a/components/profile/ProfileVoiceParts.tsx
+++ b/components/profile/ProfileVoiceParts.tsx
@@ -264,7 +264,12 @@ export function KeywordSelectView({
     : [...baseKeywords, ...selectedMoreKeywords];
 
   return (
-    <View style={styles.keywordScreen}>
+    <ScrollView
+      style={styles.keywordScroll}
+      contentContainerStyle={styles.keywordScrollContent}
+      showsVerticalScrollIndicator={false}
+      bounces={false}
+    >
       <View style={styles.keywordIntro}>
         <View style={styles.aiRow}>
           <Text style={styles.aiSparkle}>✦</Text>
@@ -370,7 +375,7 @@ export function KeywordSelectView({
           </View>
         </View>
       </Modal>
-    </View>
+    </ScrollView>
   );
 }
 
@@ -391,7 +396,12 @@ export function CompletePreviewView({
   const previewCardHeight = Math.min(472, Math.max(260, height - 420));
 
   return (
-    <View style={styles.completeScreen}>
+    <ScrollView
+      style={styles.completeScroll}
+      contentContainerStyle={styles.completeScreen}
+      showsVerticalScrollIndicator={false}
+      bounces={false}
+    >
       <View style={styles.completeTitleArea}>
         <VoiceTitle>
           {userName}님의 프로필이{"\n"}준비됐어요! 🎉
@@ -444,7 +454,7 @@ export function CompletePreviewView({
           </Text>
         </Pressable>
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
@@ -613,11 +623,11 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     lineHeight: 23,
   },
+  // ponytail: absolute bottom 대신 흐름 배치 + marginTop auto.
+  // 작은 높이에서 예시 텍스트 위로 겹치던 문제를 막는다.
   idleRecorder: {
-    position: "absolute",
-    left: 0,
-    right: 0,
-    bottom: 69,
+    marginTop: "auto",
+    marginBottom: 69,
     alignItems: "center",
   },
   coachBubbleGroup: {
@@ -665,10 +675,9 @@ const styles = StyleSheet.create({
     elevation: 8,
   },
   recordingControls: {
-    position: "absolute",
-    left: 20,
-    right: 20,
-    bottom: 23,
+    marginTop: "auto",
+    marginBottom: 23,
+    marginHorizontal: 20,
     alignItems: "center",
   },
   warningToast: {
@@ -862,10 +871,6 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     textAlign: "center",
   },
-  keywordScreen: {
-    flex: 1,
-    paddingHorizontal: 20,
-  },
   keywordIntro: {
     paddingTop: 52,
   },
@@ -983,13 +988,20 @@ const styles = StyleSheet.create({
   keywordModalChip: {
     borderRadius: 7,
   },
+  // ponytail: absolute를 걷어내 칩이 CTA 뒤로 숨지 않게 한다.
   doubleCta: {
-    position: "absolute",
-    left: 20,
-    right: 20,
-    bottom: 48,
+    marginTop: "auto",
+    paddingTop: 16,
+    marginBottom: 48,
     flexDirection: "row",
     gap: 12,
+  },
+  keywordScroll: {
+    flex: 1,
+  },
+  keywordScrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: 20,
   },
   secondaryCta: {
     flex: 1,
@@ -1019,8 +1031,11 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     lineHeight: 23,
   },
-  completeScreen: {
+  completeScroll: {
     flex: 1,
+  },
+  completeScreen: {
+    flexGrow: 1,
     paddingHorizontal: 20,
   },
   completeTitleArea: {


### PR DESCRIPTION
## 변경 사항
- iPad 호환 모드에서 잘릴 수 있는 권한·프로필 온보딩·음성 프로필 화면을 스크롤/compact-height 레이아웃으로 보완했습니다.
- 녹음·재생·키워드 CTA의 절대 위치를 일반 레이아웃 흐름으로 전환했습니다.

## 원인
심사 빌드 1.1.0 (21)에서 작은 호환 뷰포트의 고정 여백과 절대 위치 요소가 하단 콘텐츠를 가렸습니다.

## 검증
- `pnpm lint` (0 errors, 기존 warnings 3건)
- `pnpm exec tsc --noEmit`
- `npx expo-doctor` (18/18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 작은 화면에서도 온보딩 및 프로필 단계 콘텐츠를 스크롤할 수 있도록 개선했습니다.
  * 화면 높이에 따라 제목, 버튼 여백, 선택 버튼 크기와 간격이 자동으로 조정됩니다.
  * 나이 선택 피커가 화면 크기에 맞춰 표시 항목 수와 높이를 조정합니다.
  * 음성 녹음, 키워드 선택, 프로필 미리보기 화면의 콘텐츠 배치를 개선해 다양한 화면 크기에서 더 자연스럽게 표시됩니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->